### PR TITLE
Fix 404 and HTML transformation handling in `esbuild serve` task

### DIFF
--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/html.sbt
@@ -1,0 +1,64 @@
+InputKey[Unit]("html") := {
+  import org.openqa.selenium.WebDriver
+  import org.openqa.selenium.chrome.ChromeDriver
+  import org.openqa.selenium.chrome.ChromeOptions
+  import org.scalatest.matchers.should.Matchers
+  import org.scalatestplus.selenium.WebBrowser
+  import org.scalatest.concurrent.Eventually
+  import org.scalatest.concurrent.IntegrationPatience
+
+  val ags = Def.spaceDelimited().parsed.toList
+
+  val port =
+    ags match {
+      case List(port) => port
+      case _          => sys.error("missing arguments")
+    }
+
+  val webBrowser = new WebBrowser
+    with Matchers
+    with Eventually
+    with IntegrationPatience {
+    val chromeOptions: ChromeOptions = {
+      val value = new ChromeOptions
+      // arguments recommended by https://itnext.io/how-to-run-a-headless-chrome-browser-in-selenium-webdriver-c5521bc12bf0
+      value.addArguments(
+        "--disable-gpu",
+        "--window-size=1920,1200",
+        "--ignore-certificate-errors",
+        "--disable-extensions",
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+        "--headless",
+        "--remote-allow-origins=*"
+      )
+      value
+    }
+    implicit val webDriver: WebDriver = new ChromeDriver(chromeOptions)
+  }
+  import webBrowser._
+
+  eventually {
+    go to s"http://localhost:$port"
+  }
+
+  eventually {
+    find(tagName("h1")).head.text shouldBe "BASIC-WEB-PROJECT WORKS!"
+  }
+
+  // should return index instead of 404
+  go to s"http://localhost:$port/any"
+
+  eventually {
+    find(tagName("h1")).head.text shouldBe "BASIC-WEB-PROJECT WORKS!"
+  }
+
+  // should return 404 for html URLs if html file does not exist
+  go to s"http://localhost:$port/any.html"
+
+  eventually {
+    find(tagName("pre")).head.text shouldBe "HTML file [./any.html] not found"
+  }
+
+  ()
+}

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/project/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/project/html.sbt
@@ -1,0 +1,2 @@
+libraryDependencies += "org.scalatestplus" %% "selenium-4-4" % "3.2.14.0"
+libraryDependencies += "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.14"

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/src/main/scala/example/Main.scala
@@ -40,6 +40,6 @@ object Main {
   }
 
   def testString(): String = {
-    Lodash.toUpper("basic-dom-project works!")
+    Lodash.toUpper("basic-web-project works!")
   }
 }

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/src/test/scala/example/MainSpec.scala
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/src/test/scala/example/MainSpec.scala
@@ -12,7 +12,7 @@ class MainSpec extends AnyWordSpec with Matchers {
 
       document
         .querySelector("h1")
-        .textContent shouldEqual "BASIC-DOM-PROJECT WORKS!"
+        .textContent shouldEqual "BASIC-WEB-PROJECT WORKS!"
     }
   }
 }

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/test
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project/test
@@ -12,7 +12,7 @@ $ exists esbuild/package-lock.json
 $ delete esbuild/package-lock.json
 > clean
 > fastLinkJS/esbuildServeStart
-# TODO html test
+> html 8000
 > fastLinkJS/esbuildServeStop
 $ exists esbuild/package-lock.json
 
@@ -31,6 +31,6 @@ $ exists esbuild/package-lock.json
 $ delete esbuild/package-lock.json
 > clean
 > fullLinkJS/esbuildServeStart
-# TODO html test
+> html 8000
 > fullLinkJS/esbuildServeStop
 $ exists esbuild/package-lock.json

--- a/sbt-scalajs-esbuild/src/main/scala/scalajsesbuild/package.scala
+++ b/sbt-scalajs-esbuild/src/main/scala/scalajsesbuild/package.scala
@@ -111,7 +111,9 @@ package object scalajsesbuild {
       if (outputFilesDirectory.nonEmpty) {
         """publicPath: "/",""".some
       } else None
-    ).flatten.mkString.linesIterator
+    ).flatten
+      .mkString("\n")
+      .linesIterator
       .map((" " * spaces) + _)
       .mkString("\n")
   }

--- a/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project/project/html.sbt
+++ b/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project/project/html.sbt
@@ -1,0 +1,2 @@
+libraryDependencies += "org.scalatestplus" %% "selenium-4-4" % "3.2.14.0"
+libraryDependencies += "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.14"

--- a/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project/project/plugins.sbt
+++ b/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project/project/plugins.sbt
@@ -25,6 +25,3 @@ if (sourcePlugins.nonEmpty) {
     )
   )
 }
-
-libraryDependencies += "org.scalatestplus" %% "selenium-4-4" % "3.2.14.0"
-libraryDependencies += "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.14"


### PR DESCRIPTION
Currently, HTML transformations do not get applied when `404` requests get redirected back to `/` (`Vite` dev server and Webpack `historyApiFallback` behavior), this needs to be fixed.