### PR TITLE
Remove sbt-shading dependency

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.3")
-
 addSbtPlugin("me.ptrdom" % "scripted-sbt-sources" % "0.3.0")
 
 // only needed for `scala-steward-hooks`


### PR DESCRIPTION
No longer necessary since shading was removed from web plugin.