### PR TITLE
Run more of CI on JDK 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,7 @@ jobs:
         run: corepack prepare yarn@1.22.19 --activate
       - name: Setup pnpm
         run: corepack prepare pnpm@8.8.0 --activate
-      - name: Compile
-        if: ${{ matrix.jdk == 8 }}
-        run: sbt Test/compile
       - name: Run tests
-        if: ${{ matrix.jdk != 8 }}
         uses: coactions/setup-xvfb@v1
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && ' sbt-scalajs-esbuild/* sbt-scalajs-esbuild-web/* sbt-web-scalajs-esbuild/* sbt-scalajs-esbuild-electron/basic-project sbt-scalajs-esbuild-electron/e2e-test-playwright-node sbt-scalajs-esbuild-electron/electron-builder' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Run tests
         uses: coactions/setup-xvfb@v1
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && ' sbt-scalajs-esbuild/* sbt-scalajs-esbuild-web/* sbt-web-scalajs-esbuild/* sbt-scalajs-esbuild-electron/basic-project sbt-scalajs-esbuild-electron/e2e-test-playwright-node sbt-scalajs-esbuild-electron/electron-builder' || '' }}
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && ' sbt-scalajs-esbuild/* sbt-scalajs-esbuild-electron/basic-project sbt-scalajs-esbuild-electron/e2e-test-playwright-node sbt-scalajs-esbuild-electron/electron-builder' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Run tests
         uses: coactions/setup-xvfb@v1
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && ' sbt-scalajs-esbuild/* sbt-scalajs-esbuild-electron/basic-project sbt-scalajs-esbuild-electron/e2e-test-playwright-node sbt-scalajs-esbuild-electron/electron-builder' || '' }}
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && ' sbt-scalajs-esbuild/* sbt-scalajs-esbuild-electron/basic-project sbt-scalajs-esbuild-electron/e2e-test-playwright-node sbt-scalajs-esbuild-electron/electron-builder' || '' }}"

--- a/sbt-scalajs-esbuild-web/examples/multiple-entry-points/build.sbt
+++ b/sbt-scalajs-esbuild-web/examples/multiple-entry-points/build.sbt
@@ -1,4 +1,4 @@
-import java.nio.file.Path
+import java.nio.file.Paths
 
 enablePlugins(ScalaJSEsbuildWebPlugin)
 
@@ -34,8 +34,8 @@ scalaJSModuleInitializers := Seq(
 )
 
 esbuildBundleHtmlEntryPoints := Seq(
-  Path.of("index1.html"),
-  Path.of("index2.html")
+  Paths.get("index1.html"),
+  Paths.get("index2.html")
 )
 
 // Suppress meaningless 'multiple main classes detected' warning


### PR DESCRIPTION
Only tests depending on Selenium should be excluded, because they require JDK 11+. Migrate from Selenium to Playwright wherever possible.