### PR TITLE
Revert "Update scala-library to 2.13.17"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ lazy val `scala-steward-hooks` = project
   .enablePlugins(ScalaJSPlugin)
   .settings(
     publish / skip := true,
-    scalaVersion := "2.13.17",
+    scalaVersion := "2.13.16",
     libraryDependencies ++= Seq(
       "org.scala-js" %%% "scalajs-dom" % "2.8.1",
       "org.scalatest" %% "scalatest" % "3.2.19" % "test",

--- a/sbt-scalajs-esbuild-electron/examples/basic-project/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/basic-project/build.sbt
@@ -3,7 +3,7 @@ import scalajs.esbuild.electron.EsbuildElectronProcessConfiguration
 
 enablePlugins(ScalaJSEsbuildElectronPlugin)
 
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.16"
 
 scalaJSModuleInitializers := Seq(
   ModuleInitializer

--- a/sbt-scalajs-esbuild-electron/examples/e2e-test-playwright-node/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/e2e-test-playwright-node/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
     `e2e-test`
   )
 
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.16"
 
 lazy val app = (project in file("app"))
   .enablePlugins(ScalaJSEsbuildElectronPlugin)

--- a/sbt-scalajs-esbuild-electron/examples/e2e-test-selenium-jvm/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/e2e-test-selenium-jvm/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file("."))
     `e2e-test`
   )
 
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.16"
 
 lazy val app = (project in file("app"))
   .enablePlugins(ScalaJSEsbuildElectronPlugin)

--- a/sbt-scalajs-esbuild-electron/examples/electron-builder/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/electron-builder/build.sbt
@@ -5,7 +5,7 @@ import scala.sys.process._
 
 enablePlugins(ScalaJSEsbuildElectronPlugin)
 
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.16"
 
 scalaJSModuleInitializers := Seq(
   ModuleInitializer

--- a/sbt-scalajs-esbuild-web/examples/basic-web-project/build.sbt
+++ b/sbt-scalajs-esbuild-web/examples/basic-web-project/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSEsbuildWebPlugin)
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.16"
 
 scalaJSUseMainModuleInitializer := true
 

--- a/sbt-scalajs-esbuild-web/examples/multiple-entry-points/build.sbt
+++ b/sbt-scalajs-esbuild-web/examples/multiple-entry-points/build.sbt
@@ -2,7 +2,7 @@ import java.nio.file.Paths
 
 enablePlugins(ScalaJSEsbuildWebPlugin)
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.16"
 
 libraryDependencies ++= Seq(
   "org.scala-js" %%% "scalajs-dom" % "2.8.1",

--- a/sbt-scalajs-esbuild/examples/basic-browser-project/build.sbt
+++ b/sbt-scalajs-esbuild/examples/basic-browser-project/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSEsbuildPlugin)
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.16"
 
 scalaJSLinkerConfig ~= {
   _.withModuleKind(ModuleKind.ESModule)

--- a/sbt-scalajs-esbuild/examples/basic-node-project/build.sbt
+++ b/sbt-scalajs-esbuild/examples/basic-node-project/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSEsbuildPlugin)
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.16"
 
 scalaJSLinkerConfig ~= {
   _.withModuleKind(ModuleKind.CommonJSModule)

--- a/sbt-web-scalajs-esbuild/examples/basic-project/build.sbt
+++ b/sbt-web-scalajs-esbuild/examples/basic-project/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.16"
 
 lazy val `basic-project` = (project in file(".")).aggregate(client, server)
 


### PR DESCRIPTION
Reverts ptrdom/scalajs-esbuild#447

This is done to make examples compile again for the latest release. Will be addressed by PRs related to https://github.com/ptrdom/scalajs-esbuild/issues/465.