### PR TITLE
Stop processFileChanges from deleting esbuildResourcesDirectory files

### DIFF
--- a/sbt-scalajs-esbuild/src/main/scala/scalajs/esbuild/ScalaJSEsbuildPlugin.scala
+++ b/sbt-scalajs-esbuild/src/main/scala/scalajs/esbuild/ScalaJSEsbuildPlugin.scala
@@ -93,7 +93,8 @@ object ScalaJSEsbuildPlugin extends AutoPlugin {
       processFileChanges(
         fileChanges,
         esbuildResourcesDirectory.value,
-        targetDir
+        targetDir,
+        streams.value.log
       )
 
       fileChanges
@@ -178,7 +179,8 @@ object ScalaJSEsbuildPlugin extends AutoPlugin {
         processFileChanges(
           stageTaskFileChanges,
           (stageTask / scalaJSLinkerOutputDirectory).value,
-          targetDir
+          targetDir,
+          streams.value.log
         )
 
         installFileChanges ++ stageTaskFileChanges

--- a/sbt-scalajs-esbuild/src/main/scala/scalajs/esbuild/package.scala
+++ b/sbt-scalajs-esbuild/src/main/scala/scalajs/esbuild/package.scala
@@ -48,33 +48,54 @@ package object esbuild {
   private[esbuild] def processFileChanges(
       fileChanges: FileChanges,
       sourceDirectory: File,
-      targetDirectory: File
+      targetDirectory: File,
+      logger: Logger
   ): Unit = {
-    def toTargetFile(
-        sourcePath: Path,
-        sourceDirectory: File,
-        targetDirectory: File
-    ): File = {
-      new File(
-        sourcePath.toFile.getAbsolutePath.replace(
-          sourceDirectory.getAbsolutePath,
-          targetDirectory.getAbsolutePath
-        )
-      )
-    }
+    val sourceDirPath = sourceDirectory.toPath.toAbsolutePath.normalize
+    val targetDirPath = targetDirectory.toPath.toAbsolutePath.normalize
 
-    (fileChanges.created ++ fileChanges.modified)
-      .foreach { path =>
-        IO.copyFile(
-          path.toFile,
-          toTargetFile(path, sourceDirectory, targetDirectory)
-        )
+    def isUnderSource(path: Path): Boolean =
+      path.toAbsolutePath.normalize.startsWith(sourceDirPath)
+
+    def toTargetFile(sourcePath: Path): File =
+      targetDirPath
+        .resolve(sourceDirPath.relativize(sourcePath.toAbsolutePath.normalize))
+        .toFile
+
+    // Only `deleted` can contain entries outside sourceDirectory: created,
+    // modified and unmodified come from globbing current files and so always
+    // live under the current sourceDirectory. A `deleted` path that does not
+    // is a sign sbt's fileInputs cache references a previous sourceDirectory
+    // value (e.g. esbuildResourcesDirectory was reassigned, or `clean` only
+    // partially cleared the change-tracking cache).
+    val staleDeleted = fileChanges.deleted.filterNot(isUnderSource)
+
+    if (staleDeleted.nonEmpty) {
+      // Translating those paths through targetDirectory would either produce
+      // a `..`-escaping path or - with the previous String.replace
+      // implementation - silently delete files in the user's source tree.
+      // Recover by copying every file currently visible under sourceDirectory,
+      // equivalent to a post-`clean` first run; sbt commits the file stamps
+      // at end-of-task, so the cache is back in sync for subsequent runs.
+      logger.warn(
+        s"Detected ${staleDeleted.size} stale fileInputs deletion entr" +
+          (if (staleDeleted.size == 1) "y" else "ies") +
+          s" outside sourceDirectory [$sourceDirPath]; " +
+          "falling back to a full copy of sourceDirectory into " +
+          s"[$targetDirPath]."
+      )
+      (fileChanges.created ++ fileChanges.modified ++ fileChanges.unmodified)
+        .foreach { path =>
+          IO.copyFile(path.toFile, toTargetFile(path))
+        }
+    } else {
+      (fileChanges.created ++ fileChanges.modified)
+        .foreach { path =>
+          IO.copyFile(path.toFile, toTargetFile(path))
+        }
+      fileChanges.deleted.foreach { path =>
+        IO.delete(toTargetFile(path))
       }
-
-    fileChanges.deleted.foreach { path =>
-      IO.delete(
-        toTargetFile(path, sourceDirectory, targetDirectory)
-      )
     }
   }
 

--- a/sbt-scalajs-esbuild/src/sbt-test/sbt-scalajs-esbuild/esbuild-resources-not-deleted-snapshot/.sources
+++ b/sbt-scalajs-esbuild/src/sbt-test/sbt-scalajs-esbuild/esbuild-resources-not-deleted-snapshot/.sources
@@ -1,0 +1,2 @@
+src/sbt-test-utilities
+examples/basic-browser-project

--- a/sbt-scalajs-esbuild/src/sbt-test/sbt-scalajs-esbuild/esbuild-resources-not-deleted-snapshot/test
+++ b/sbt-scalajs-esbuild/src/sbt-test/sbt-scalajs-esbuild/esbuild-resources-not-deleted-snapshot/test
@@ -1,0 +1,34 @@
+# Files in esbuildResourcesDirectory must never be deleted by the plugin.
+# Strategy: prime the esbuildCopyResources fileInputs cache pointing at esbuild/,
+# then re-point esbuildResourcesDirectory at a sibling directory and re-run. The
+# previous-run's cached paths are reported as `deleted` against the new source
+# directory and so they fall outside sourceDirectory in processFileChanges.
+# Before the fix this silently deleted files in the user's source tree; after
+# the fix processFileChanges detects the stale cache and falls back to a full
+# copy of the new sourceDirectory (equivalent to a post-`clean` first run),
+# leaving the original source tree untouched.
+
+# Add a synthetic resource so we can prove non-lockfile resources survive.
+$ touch esbuild/index.html
+
+# Prime the inputFileChanges cache against esbuild/.
+> Compile/esbuildCopyResources
+
+# Sanity: the source resources are present before the switch.
+$ exists esbuild/index.html
+$ exists esbuild/package.json
+
+# Mirror the resources into the alternate directory so the second run has valid inputs.
+$ copy-file esbuild/index.html esbuild-alt/index.html
+$ copy-file esbuild/package.json esbuild-alt/package.json
+
+# Switch the resources directory. The cached entries from the previous run still
+# reference paths under esbuild/, which lie outside the new sourceDirectory.
+# processFileChanges should detect this and fall back to a full copy rather
+# than translating those paths (which previously deleted files in esbuild/).
+> set Compile / esbuildResourcesDirectory := baseDirectory.value / "esbuild-alt"
+> Compile/esbuildCopyResources
+
+# Source-tree resources in the original esbuild/ directory must still be intact.
+$ exists esbuild/index.html
+$ exists esbuild/package.json


### PR DESCRIPTION
## Summary

- `processFileChanges` translated source paths to target paths via `String.replace` of `sourceDirectory.getAbsolutePath`. When the substring didn''t match — typically because sbt''s `fileInputs` cache referenced a previous `esbuildResourcesDirectory` — the helper returned the source path unchanged and `IO.delete` erased it from the user''s source tree. Lockfiles only seemed to survive because `esbuildPackageManagerInstall` re-copies them after every install.
- Replaced the translation with `Path.relativize` / `resolve`. When any `deleted` entry falls outside the current `sourceDirectory`, log a warning and fall back to a full copy of `sourceDirectory` into `targetDirectory` (equivalent to a post-`clean` first run); sbt commits the new file stamps at end-of-task.
- New scripted test `esbuild-resources-not-deleted-snapshot` primes the cache against `esbuild/`, re-points `esbuildResourcesDirectory` at a sibling, runs `esbuildCopyResources`, and asserts the original files are still on disk.

Generated with [Claude Code](https://claude.com/claude-code)