### PR TITLE
Stabilize Windows CI: serialize scripted, retry fast-fails, prime corepack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
             test-suffix: snapshot
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      SBT_SCRIPTED_TARGETS: ${{ matrix.jdk == 8 && format('sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format('*/*-{0}', matrix.test-suffix) }}
     steps:
       - uses: actions/checkout@v6
       - uses: coursier/cache-action@v8
@@ -51,9 +53,32 @@ jobs:
           corepack prepare pnpm@10.33.2
           corepack prepare yarn@1.22.22
           corepack prepare yarn@4.14.1
-      - name: Run tests
+      - name: Run tests (Linux/macOS)
+        if: ${{ !startsWith(matrix.os, 'windows-') }}
         uses: coactions/setup-xvfb@v1
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
+          SBT_SCRIPTED: ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ (startsWith(matrix.os, 'windows-') && steps.coursier-cache.outputs.cache-hit-coursier) && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && format(' sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format(' */*-{0}', matrix.test-suffix) }}"
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test "$SBT_SCRIPTED $SBT_SCRIPTED_TARGETS"
+      - name: Run tests (Windows, retry on Windows fast-fail)
+        if: startsWith(matrix.os, 'windows-')
+        shell: pwsh
+        env:
+          E2E_TEST_BROWSER: ${{ matrix.browser }}
+        run: |
+          $maxAttempts = 3
+          $logFile = Join-Path $env:RUNNER_TEMP 'sbt-run.log'
+          $tasks = ("scriptedSequentialPerModule $env:SBT_SCRIPTED_TARGETS" -split '\s+') | Where-Object { $_ -ne '' }
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            if (Test-Path $logFile) { Remove-Item $logFile -Force }
+            & sbt scalafmtSbtCheck scalafmtCheckAll test @tasks *>&1 | Tee-Object -FilePath $logFile
+            $exit = $LASTEXITCODE
+            if ($exit -eq 0) { exit 0 }
+            $log = if (Test-Path $logFile) { Get-Content $logFile -Raw } else { '' }
+            if ($attempt -lt $maxAttempts -and $log -match 'Nonzero exit value: -1073740791') {
+              Write-Host "::warning::Windows fast-fail (-1073740791) detected; retrying sbt (attempt $($attempt+1)/$maxAttempts). See actions/runner-images#13629."
+              continue
+            }
+            exit $exit
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,13 @@ jobs:
           node-version: 24.15.0
       - name: Enable Corepack
         run: corepack enable
+      - name: Prime corepack package managers (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          corepack prepare pnpm@10.33.2
+          corepack prepare yarn@1.22.22
+          corepack prepare yarn@4.14.1
       - name: Run tests
         uses: coactions/setup-xvfb@v1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && format(' sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format(' */*-{0}', matrix.test-suffix) }}"
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ (matrix.os != 'windows-latest' && steps.coursier-cache.outputs.cache-hit-coursier) && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && format(' sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format(' */*-{0}', matrix.test-suffix) }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,8 @@ jobs:
         uses: coactions/setup-xvfb@v1
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
-          SBT_SCRIPTED: ${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }}
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test "$SBT_SCRIPTED $SBT_SCRIPTED_TARGETS"
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }} ${{ env.SBT_SCRIPTED_TARGETS }}"
       - name: Run tests (Windows, retry on Windows fast-fail)
         if: startsWith(matrix.os, 'windows-')
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,16 @@ jobs:
             $exit = $LASTEXITCODE
             if ($exit -eq 0) { exit 0 }
             $log = if (Test-Path $logFile) { Get-Content $logFile -Raw } else { '' }
-            if ($attempt -lt $maxAttempts -and $log -match 'Nonzero exit value: -1073740791') {
-              Write-Host "::warning::Windows fast-fail (-1073740791) detected; retrying scripted (attempt $($attempt+1)/$maxAttempts). See actions/runner-images#13629."
+            $retryReason = $null
+            if ($log -match 'Nonzero exit value: -1073740791') {
+              $retryReason = 'Windows fast-fail (-1073740791); see actions/runner-images#13629'
+            } elseif ($log -match 'Could not create lock for .*sbt-(load|server).*_lock' -or $log -match 'ServerAlreadyBootingException') {
+              $retryReason = 'sbt named-pipe lock race on boot; see sbt/sbt#6777'
+            }
+            if ($attempt -lt $maxAttempts -and $retryReason) {
+              Write-Host "::warning::$retryReason. Retrying scripted (attempt $($attempt+1)/$maxAttempts)."
+              Get-Process -Name java,sbt,sbtn,node,esbuild -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+              Start-Sleep -Seconds 10
               continue
             }
             exit $exit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [8, 11, 17, 21, 25]
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-22.04, windows-2025]
         browser: ["${{ vars.E2E_TEST_BROWSER }}"]
         experimental: [false]
         test-suffix: [release, snapshot]
@@ -45,7 +45,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Prime corepack package managers (Windows)
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows-')
         shell: bash
         run: |
           corepack prepare pnpm@10.33.2
@@ -56,4 +56,4 @@ jobs:
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ (matrix.os != 'windows-latest' && steps.coursier-cache.outputs.cache-hit-coursier) && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && format(' sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format(' */*-{0}', matrix.test-suffix) }}"
+          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ (startsWith(matrix.os, 'windows-') && steps.coursier-cache.outputs.cache-hit-coursier) && 'scripted' || 'scriptedSequentialPerModule' }}${{ matrix.jdk == 8 && format(' sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format(' */*-{0}', matrix.test-suffix) }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     env:
+      SBT_CHECK_TASKS: scalafmtSbtCheck scalafmtCheckAll test
       SBT_SCRIPTED_TARGETS: ${{ matrix.jdk == 8 && format('sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format('*/*-{0}', matrix.test-suffix) }}
     steps:
       - uses: actions/checkout@v6
@@ -59,24 +60,26 @@ jobs:
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
         with:
-          run: sbt scalafmtSbtCheck scalafmtCheckAll test "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }} ${{ env.SBT_SCRIPTED_TARGETS }}"
-      - name: Run tests (Windows, retry on Windows fast-fail)
+          run: sbt ${{ env.SBT_CHECK_TASKS }} "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }} ${{ env.SBT_SCRIPTED_TARGETS }}"
+      - name: Run tests (Windows, retry scripted on Windows fast-fail)
         if: startsWith(matrix.os, 'windows-')
         shell: pwsh
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
         run: |
+          & sbt ${{ env.SBT_CHECK_TASKS }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $maxAttempts = 3
-          $logFile = Join-Path $env:RUNNER_TEMP 'sbt-run.log'
-          $tasks = ("scriptedSequentialPerModule $env:SBT_SCRIPTED_TARGETS" -split '\s+') | Where-Object { $_ -ne '' }
+          $logFile = Join-Path $env:RUNNER_TEMP 'sbt-scripted.log'
+          $scripted = "scriptedSequentialPerModule $env:SBT_SCRIPTED_TARGETS"
           for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
             if (Test-Path $logFile) { Remove-Item $logFile -Force }
-            & sbt scalafmtSbtCheck scalafmtCheckAll test @tasks *>&1 | Tee-Object -FilePath $logFile
+            & sbt $scripted *>&1 | Tee-Object -FilePath $logFile
             $exit = $LASTEXITCODE
             if ($exit -eq 0) { exit 0 }
             $log = if (Test-Path $logFile) { Get-Content $logFile -Raw } else { '' }
             if ($attempt -lt $maxAttempts -and $log -match 'Nonzero exit value: -1073740791') {
-              Write-Host "::warning::Windows fast-fail (-1073740791) detected; retrying sbt (attempt $($attempt+1)/$maxAttempts). See actions/runner-images#13629."
+              Write-Host "::warning::Windows fast-fail (-1073740791) detected; retrying scripted (attempt $($attempt+1)/$maxAttempts). See actions/runner-images#13629."
               continue
             }
             exit $exit

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,13 @@ lazy val commonSettings = Seq(
   scriptedLaunchOpts ++= Seq(
     "-Dplugin.version=" + version.value
   ),
-  scriptedBufferLog := false
+  scriptedBufferLog := false,
+  // workaround for https://github.com/sbt/sbt/issues/7431 - on Windows CI the
+  // sbt named-pipe lock races during batch-mode reload; disable batching there
+  scriptedBatchExecution := !(
+    sys.props.get("os.name").exists(_.toLowerCase.contains("win")) &&
+      sys.env.get("CI").contains("true")
+  )
 )
 
 lazy val `sbt-scalajs-esbuild` =

--- a/build.sbt
+++ b/build.sbt
@@ -35,12 +35,7 @@ lazy val commonSettings = Seq(
     "-Dplugin.version=" + version.value
   ),
   scriptedBufferLog := false,
-  // workaround for https://github.com/sbt/sbt/issues/7431 - on Windows CI the
-  // sbt named-pipe lock races during batch-mode reload; disable batching there
-  scriptedBatchExecution := !(
-    sys.props.get("os.name").exists(_.toLowerCase.contains("win")) &&
-      sys.env.get("CI").contains("true")
-  )
+  scriptedBatchExecution := !(isWindows && isCI)
 )
 
 lazy val `sbt-scalajs-esbuild` =
@@ -128,3 +123,7 @@ lazy val `scala-steward-hooks` = project
       "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1"
     )
   )
+
+lazy val isWindows =
+  sys.props.get("os.name").exists(_.toLowerCase.contains("win"))
+lazy val isCI = sys.env.get("CI").contains("true")

--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,25 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions", "npm"],
+  "enabledManagers": ["github-actions", "npm", "custom.regex"],
   "ignorePaths": [],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["corepack prepare (?<depName>[\\w@/-]+?)@(?<currentValue>\\S+)"],
+      "datasourceTemplate": "npm"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["electron", "electron-chromedriver"],
       "groupName": "electron"
+    },
+    {
+      "matchPackageNames": ["yarn"],
+      "matchCurrentVersion": "/^1\\./",
+      "allowedVersions": "<2.0.0"
     }
   ]
 }

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project-snapshot/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project-snapshot/html.sbt
@@ -88,7 +88,15 @@ InputKey[Unit]("html") := {
       eventually {
         pageSource should include("HTML file [./any.html] not found")
       }
-    } withClue s"Page source:\n[$pageSource]"
+    } withClue {
+      val maybePageSource =
+        try pageSource
+        catch {
+          case t: Throwable =>
+            s"<pageSource threw ${t.getClass.getName}: ${t.getMessage}>"
+        }
+      s"Page source:\n[$maybePageSource]"
+    }
   } finally {
     webBrowser.webDriver.quit()
   }

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/multiple-entry-points-snapshot/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/multiple-entry-points-snapshot/html.sbt
@@ -99,7 +99,15 @@ InputKey[Unit]("html") := {
       eventually {
         pageSource should include("404 - Not Found")
       }
-    } withClue s"Page source:\n[$pageSource]"
+    } withClue {
+      val maybePageSource =
+        try pageSource
+        catch {
+          case t: Throwable =>
+            s"<pageSource threw ${t.getClass.getName}: ${t.getMessage}>"
+        }
+      s"Page source:\n[$maybePageSource]"
+    }
   } finally {
     webBrowser.webDriver.quit()
   }

--- a/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project-snapshot/html.sbt
+++ b/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project-snapshot/html.sbt
@@ -61,7 +61,15 @@ InputKey[Unit]("html") := {
       eventually {
         find(tagName("h1")).head.text shouldBe "BASIC-PROJECT-SBT-WEB WORKS!"
       }
-    } withClue s"Page source:\n[$pageSource]"
+    } withClue {
+      val maybePageSource =
+        try pageSource
+        catch {
+          case t: Throwable =>
+            s"<pageSource threw ${t.getClass.getName}: ${t.getMessage}>"
+        }
+      s"Page source:\n[$maybePageSource]"
+    }
   } finally {
     webBrowser.webDriver.quit()
   }


### PR DESCRIPTION
## Summary

Windows CI has been red on every run since 2026-05-02. Failures rotate randomly across JDKs and `test-suffix`; Linux and macOS always pass. Three failure modes recur, and this PR addresses each.

### Observed failure modes

1. `IOException: Could not create lock for \\.\pipe\sbt-load_lock, error 1336` — surfaces as `Remote sbt initialization failed` / `ServerAlreadyBootingException` during `getSocketOrExit`. Tracked upstream as sbt/sbt#6777.
2. `Nonzero exit value: -1073740791` (0xC0000409 `STATUS_STACK_BUFFER_OVERRUN`) from spawned `npm` / `esbuild` / `electron` child processes. Tracked upstream as actions/runner-images#13629 and only reproduces on the GitHub-hosted Windows image.
3. Selenium `head of empty list` whose page source is Firefox's `about:neterror` template — the esbuild dev server never bound on its port in time, usually because corepack was still installing `pnpm` / `yarn` on first use.

### Changes

1. **Always serialize scripted tests on Windows CI.** The previous workflow only used `scriptedSequentialPerModule` on coursier cache miss, so warm-cache Windows runs (the common case) hit parallel `scripted` and flaked. Force the sequential path on Windows; leave the warm-cache parallel path intact for Linux and macOS.
2. **Disable scripted batch execution on Windows CI.** `scriptedSequentialPerModule` alone is not enough: each module still runs its tests inside one batched sbt JVM that reloads sbt between tests, and the reload re-binds the sbt server's named pipe — which is what sbt/sbt#6777 races. Set `scriptedBatchExecution := false` so each scripted test runs in its own sbt JVM, making the named pipe a one-shot per test. Gated on `os.name` containing `win` AND `CI=true` so local Windows development is unaffected.
3. **Pin the Windows runner to `windows-2025`.** `windows-latest` is mid-rollout to 2025 and the rollout itself adds variance; pinning gives a stable target.
4. **Retry scripted up to 3 times on Windows for transient infra failures.** Split the Windows `Run tests` step from the Linux/macOS one (the latter still uses `coactions/setup-xvfb`). On Windows, run `scalafmtSbtCheck scalafmtCheckAll test` once non-retried, then loop `scriptedSequentialPerModule ...` while teeing output. The log is matched against two retryable patterns: `Nonzero exit value: -1073740791` (the runner-images#13629 fast-fail) and `Could not create lock for ...sbt-(load|server)..._lock` / `ServerAlreadyBootingException` (the sbt/sbt#6777 named-pipe race on boot). Between attempts the loop kills straggler `java` / `sbt` / `sbtn` / `node` / `esbuild` processes left by the failed run and waits 10 seconds so the named-pipe namespace drains before the next sbt boot. The `::warning::` annotation names which pattern triggered the retry. Any non-matching failure exits immediately, so unrelated breakages still surface.
5. **Prime corepack package managers before scripted tests on Windows.** `corepack prepare pnpm@... yarn@1.x yarn@4.x` up front; on cold runners corepack's first-use download otherwise raced the esbuild dev server startup and tripped the Selenium `neterror` failure.
6. **Teach Renovate to track corepack-pinned versions.** Custom regex manager for `corepack prepare <pkg>@<version>` lines under `.github/workflows/`, plus a `yarn` package rule that holds 1.x at <2.0.0 so the classic-yarn pin doesn't get bumped to Berry.
7. **Capture `pageSource` defensively in the scripted `html` tasks' `withClue`.** When a Selenium assertion in the `try` block fails *after* the WebDriver session has gone away (e.g. browser crash, geckodriver exit), evaluating `pageSource` in the clue itself throws and masks the original `TestFailedDueToTimeoutException` with a `WebDriverException` whose message is empty on Windows — leaving the failure logged as `[error] (html)` with nothing after. Wrap the `pageSource` read in a `try`/`catch` that records the failure inline so the original assertion exception survives.

Generated with [Claude Code](https://claude.com/claude-code)
