### PR TITLE
Drop redundant JDKs from CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17, 21, 25]
+        jdk: [8, 25]
         os: [ubuntu-22.04, windows-2025]
         browser: ["${{ vars.E2E_TEST_BROWSER }}"]
         experimental: [false]


### PR DESCRIPTION
## Summary

- Drop JDK 11, 17, and 21 from the CI matrix in `.github/workflows/test.yml`.
- The only JDK-sensitive code path in the plugin is the reflection fallback for `Process.descendants()` in `ScalaJSEsbuildWebPlugin` -- JDK 8 hits the fallback, every JDK 9+ hits the same modern path.
- Keep JDK 8 (exercises the fallback) and JDK 25 (newest LTS, modern representative); the dropped JDKs added no plugin-implementation coverage.

Generated with [Claude Code](https://claude.com/claude-code)