### PR TITLE
Route yarn berry through @yarnpkg/cli in regex manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,18 @@
       "managerFilePatterns": [
         "/^\\.github/workflows/.*\\.ya?ml$/"
       ],
-      "matchStrings": ["corepack prepare (?<depName>[\\w@/-]+?)@(?<currentValue>\\S+)"],
+      "matchStrings": [
+        "corepack prepare (?<depName>pnpm)@(?<currentValue>\\S+)",
+        "corepack prepare (?<depName>yarn)@(?<currentValue>1\\.\\S+)"
+      ],
+      "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["corepack prepare yarn@(?<currentValue>[2-9]\\d*\\.\\S+)"],
+      "depNameTemplate": "yarn",
+      "packageNameTemplate": "@yarnpkg/cli",
       "datasourceTemplate": "npm"
     }
   ],


### PR DESCRIPTION
## Summary
- Split the custom regex manager into two entries so yarn berry (4.x) is looked up against `@yarnpkg/cli` on npm, while pnpm and yarn 1.x keep the default `yarn` / `pnpm` npm package lookup.
- Fixes Renovate not finding updates for `corepack prepare yarn@4.x` lines in `.github/workflows/*.yml`. The `yarn` npm package only publishes up to 2.4.3, so the previous single regex manager saw no candidate versions and PR #620 only touched `berry/package.json`, leaving the workflow line stale.

Generated with [Claude Code](https://claude.com/claude-code)