### PR TITLE
Cancel in-progress workflow runs when new commits are pushed

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -8,6 +8,10 @@ on:
 
 name: Launch Scala Steward
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scala-steward:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
       - main
   schedule:
     - cron: '0 12 * * 1'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary
- Add a `concurrency` block to the Test and Launch Scala Steward workflows so that pushing new commits to the same branch or PR cancels any in-progress run for that workflow.
- Group is `${{ github.workflow }}-${{ github.ref }}`, so PRs (`refs/pull/N/merge`) are isolated per PR and different workflows never collide. Runs on `main` triggered by push/schedule/dispatch share a group and will supersede each other -- acceptable here since both jobs are idempotent.

Generated with [Claude Code](https://claude.com/claude-code)