### PR TITLE
Pin browser and driver versions for Selenium scripted tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,11 +57,41 @@ jobs:
           corepack prepare pnpm@10.33.2
           corepack prepare yarn@1.22.22
           corepack prepare yarn@4.15.0
+          corepack prepare yarn@4.14.1
+      # Pin the browser + driver used by Selenium scripted tests so an updated
+      # runner image can't break the build. Versions bumped here are reviewed
+      # like any other dependency. matrix.browser is empty by default and may
+      # be set via the E2E_TEST_BROWSER repo variable; treat empty as 'chrome'.
+      - name: Setup Chrome
+        if: matrix.browser == 'chrome' || matrix.browser == ''
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: '149.0.7827.22'
+          install-chromedriver: true
+      - name: Setup Firefox
+        if: matrix.browser == 'firefox'
+        id: setup-firefox
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: '151.0.1'
+      - name: Setup geckodriver
+        if: matrix.browser == 'firefox'
+        id: setup-geckodriver
+        # No semver tags upstream (only v0.0.0); pin by SHA. Renovate's
+        # github-actions manager tracks main and proposes digest bumps.
+        uses: browser-actions/setup-geckodriver@bf8266f624ca122cedb6d0381a031f18f6c431cd
+        with:
+          geckodriver-version: '0.36.0'
       - name: Run tests (Linux/macOS)
         if: ${{ !startsWith(matrix.os, 'windows-') }}
         uses: coactions/setup-xvfb@v1
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
+          CHROMEDRIVER_BIN: ${{ steps.setup-chrome.outputs.chromedriver-path }}
+          FIREFOX_BIN: ${{ steps.setup-firefox.outputs.firefox-path }}
+          GECKODRIVER_BIN: ${{ steps.setup-geckodriver.outputs.geckodriver-path }}
         with:
           run: sbt ${{ env.SBT_CHECK_TASKS }} "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }} ${{ env.SBT_SCRIPTED_TARGETS }}"
       - name: Run tests (Windows, retry scripted on Windows fast-fail)
@@ -69,6 +99,10 @@ jobs:
         shell: pwsh
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
+          CHROMEDRIVER_BIN: ${{ steps.setup-chrome.outputs.chromedriver-path }}
+          FIREFOX_BIN: ${{ steps.setup-firefox.outputs.firefox-path }}
+          GECKODRIVER_BIN: ${{ steps.setup-geckodriver.outputs.geckodriver-path }}
         run: |
           & sbt ${{ env.SBT_CHECK_TASKS }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,11 @@ jobs:
       - name: Setup geckodriver
         if: matrix.browser == 'firefox'
         id: setup-geckodriver
-        # No semver tags upstream (only v0.0.0); pin by SHA. Renovate's
-        # github-actions manager tracks main and proposes digest bumps.
-        uses: browser-actions/setup-geckodriver@bf8266f624ca122cedb6d0381a031f18f6c431cd
+        # No semver tags upstream (only v0.0.0); upstream publishes the built
+        # action on the `latest` branch. Pin by SHA and use the `# latest`
+        # comment so Renovate's github-actions manager tracks that branch's
+        # head and proposes digest bumps.
+        uses: browser-actions/setup-geckodriver@fac5b0424c584257f32cf12c5eb4ba86014c34f8 # latest
         with:
           geckodriver-version: '0.36.0'
       - name: Run tests (Linux/macOS)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,42 +58,18 @@ jobs:
           corepack prepare yarn@1.22.22
           corepack prepare yarn@4.15.0
           corepack prepare yarn@4.14.1
-      # Pin the browser + driver used by Selenium scripted tests so an updated
-      # runner image can't break the build. Versions bumped here are reviewed
-      # like any other dependency. matrix.browser is empty by default and may
-      # be set via the E2E_TEST_BROWSER repo variable; treat empty as 'chrome'.
-      - name: Setup Chrome
-        if: matrix.browser == 'chrome' || matrix.browser == ''
-        id: setup-chrome
-        uses: browser-actions/setup-chrome@v1
+      - name: Cache Selenium Manager browsers
+        uses: actions/cache@v4
         with:
-          chrome-version: '149.0.7827.22'
-          install-chromedriver: true
-      - name: Setup Firefox
-        if: matrix.browser == 'firefox'
-        id: setup-firefox
-        uses: browser-actions/setup-firefox@v1
-        with:
-          firefox-version: '151.0.1'
-      - name: Setup geckodriver
-        if: matrix.browser == 'firefox'
-        id: setup-geckodriver
-        # No semver tags upstream (only v0.0.0); upstream publishes the built
-        # action on the `latest` branch. Pin by SHA and use the `# latest`
-        # comment so Renovate's github-actions manager tracks that branch's
-        # head and proposes digest bumps.
-        uses: browser-actions/setup-geckodriver@fac5b0424c584257f32cf12c5eb4ba86014c34f8 # latest
-        with:
-          geckodriver-version: '0.36.0'
+          path: ~/.cache/selenium
+          key: selenium-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('**/sbt-test/**/html.sbt') }}
+          restore-keys: |
+            selenium-${{ runner.os }}-${{ matrix.browser }}-
       - name: Run tests (Linux/macOS)
         if: ${{ !startsWith(matrix.os, 'windows-') }}
         uses: coactions/setup-xvfb@v1
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
-          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
-          CHROMEDRIVER_BIN: ${{ steps.setup-chrome.outputs.chromedriver-path }}
-          FIREFOX_BIN: ${{ steps.setup-firefox.outputs.firefox-path }}
-          GECKODRIVER_BIN: ${{ steps.setup-geckodriver.outputs.geckodriver-path }}
         with:
           run: sbt ${{ env.SBT_CHECK_TASKS }} "${{ steps.coursier-cache.outputs.cache-hit-coursier && 'scripted' || 'scriptedSequentialPerModule' }} ${{ env.SBT_SCRIPTED_TARGETS }}"
       - name: Run tests (Windows, retry scripted on Windows fast-fail)
@@ -101,10 +77,6 @@ jobs:
         shell: pwsh
         env:
           E2E_TEST_BROWSER: ${{ matrix.browser }}
-          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
-          CHROMEDRIVER_BIN: ${{ steps.setup-chrome.outputs.chromedriver-path }}
-          FIREFOX_BIN: ${{ steps.setup-firefox.outputs.firefox-path }}
-          GECKODRIVER_BIN: ${{ steps.setup-geckodriver.outputs.geckodriver-path }}
         run: |
           & sbt ${{ env.SBT_CHECK_TASKS }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,22 @@
   ],
   "enabledManagers": ["github-actions", "npm", "custom.regex"],
   "ignorePaths": [],
+  "customDatasources": {
+    "chrome-for-testing-stable": {
+      "defaultRegistryUrlTemplate": "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": $.channels.Stable.version}]}"
+      ]
+    },
+    "firefox-releases": {
+      "defaultRegistryUrlTemplate": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": $.LATEST_FIREFOX_VERSION}]}"
+      ]
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -24,6 +40,29 @@
       "depNameTemplate": "yarn",
       "packageNameTemplate": "@yarnpkg/cli",
       "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["chrome-version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
+      "depNameTemplate": "chrome-for-testing",
+      "datasourceTemplate": "custom.chrome-for-testing-stable",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["firefox-version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
+      "depNameTemplate": "firefox",
+      "datasourceTemplate": "custom.firefox-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["geckodriver-version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
+      "depNameTemplate": "mozilla/geckodriver",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -35,6 +74,14 @@
       "matchPackageNames": ["yarn"],
       "matchCurrentVersion": "/^1\\./",
       "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchPackageNames": ["chrome-for-testing"],
+      "groupName": "chrome"
+    },
+    {
+      "matchPackageNames": ["firefox", "mozilla/geckodriver"],
+      "groupName": "firefox"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": ["corepack prepare yarn@(?<currentValue>[2-9]\\d*\\.\\S+)"],
       "depNameTemplate": "yarn",
       "packageNameTemplate": "@yarnpkg/cli",
@@ -43,26 +43,18 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
-      "matchStrings": ["chrome-version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
+      "managerFilePatterns": ["/sbt-test/.+/html\\.sbt$/"],
+      "matchStrings": ["val\\s+chromeForTestingVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "chrome-for-testing",
       "datasourceTemplate": "custom.chrome-for-testing-stable",
       "versioningTemplate": "loose"
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
-      "matchStrings": ["firefox-version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
+      "managerFilePatterns": ["/sbt-test/.+/html\\.sbt$/"],
+      "matchStrings": ["val\\s+firefoxVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "firefox",
       "datasourceTemplate": "custom.firefox-releases"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
-      "matchStrings": ["geckodriver-version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
-      "depNameTemplate": "mozilla/geckodriver",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -80,7 +72,7 @@
       "groupName": "chrome"
     },
     {
-      "matchPackageNames": ["firefox", "mozilla/geckodriver"],
+      "matchPackageNames": ["firefox"],
       "groupName": "firefox"
     }
   ]

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project-snapshot/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project-snapshot/html.sbt
@@ -42,11 +42,27 @@ InputKey[Unit]("html") := {
         .map(_.toLowerCase)
         .getOrElse("chrome") match {
         case "chrome" =>
+          sys.env
+            .get("CHROMEDRIVER_BIN")
+            .filter(_.nonEmpty)
+            .foreach(System.setProperty("webdriver.chrome.driver", _))
           val options = new ChromeOptions
+          sys.env
+            .get("CHROME_BIN")
+            .filter(_.nonEmpty)
+            .foreach(options.setBinary)
           options.addArguments(arguments: _*)
           new ChromeDriver(options)
         case "firefox" =>
+          sys.env
+            .get("GECKODRIVER_BIN")
+            .filter(_.nonEmpty)
+            .foreach(System.setProperty("webdriver.gecko.driver", _))
           val options = new FirefoxOptions
+          sys.env
+            .get("FIREFOX_BIN")
+            .filter(_.nonEmpty)
+            .foreach(options.setBinary)
           options.addArguments(arguments: _*)
           new FirefoxDriver(options)
         case unhandled =>

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project-snapshot/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/basic-web-project-snapshot/html.sbt
@@ -21,6 +21,11 @@ InputKey[Unit]("html") := {
       case _          => sys.error("missing arguments")
     }
 
+  // Pinned so Selenium Manager fetches a deterministic browser+driver pair
+  // both locally and in CI, instead of resolving against whatever is on PATH.
+  val chromeForTestingVersion = "149.0.7827.22"
+  val firefoxVersion = "151.0.1"
+
   val webBrowser = new WebBrowser
     with Matchers
     with Eventually
@@ -42,27 +47,13 @@ InputKey[Unit]("html") := {
         .map(_.toLowerCase)
         .getOrElse("chrome") match {
         case "chrome" =>
-          sys.env
-            .get("CHROMEDRIVER_BIN")
-            .filter(_.nonEmpty)
-            .foreach(System.setProperty("webdriver.chrome.driver", _))
           val options = new ChromeOptions
-          sys.env
-            .get("CHROME_BIN")
-            .filter(_.nonEmpty)
-            .foreach(options.setBinary)
+          options.setBrowserVersion(chromeForTestingVersion)
           options.addArguments(arguments: _*)
           new ChromeDriver(options)
         case "firefox" =>
-          sys.env
-            .get("GECKODRIVER_BIN")
-            .filter(_.nonEmpty)
-            .foreach(System.setProperty("webdriver.gecko.driver", _))
           val options = new FirefoxOptions
-          sys.env
-            .get("FIREFOX_BIN")
-            .filter(_.nonEmpty)
-            .foreach(options.setBinary)
+          options.setBrowserVersion(firefoxVersion)
           options.addArguments(arguments: _*)
           new FirefoxDriver(options)
         case unhandled =>

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/multiple-entry-points-snapshot/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/multiple-entry-points-snapshot/html.sbt
@@ -42,11 +42,27 @@ InputKey[Unit]("html") := {
         .map(_.toLowerCase)
         .getOrElse("chrome") match {
         case "chrome" =>
+          sys.env
+            .get("CHROMEDRIVER_BIN")
+            .filter(_.nonEmpty)
+            .foreach(System.setProperty("webdriver.chrome.driver", _))
           val options = new ChromeOptions
+          sys.env
+            .get("CHROME_BIN")
+            .filter(_.nonEmpty)
+            .foreach(options.setBinary)
           options.addArguments(arguments: _*)
           new ChromeDriver(options)
         case "firefox" =>
+          sys.env
+            .get("GECKODRIVER_BIN")
+            .filter(_.nonEmpty)
+            .foreach(System.setProperty("webdriver.gecko.driver", _))
           val options = new FirefoxOptions
+          sys.env
+            .get("FIREFOX_BIN")
+            .filter(_.nonEmpty)
+            .foreach(options.setBinary)
           options.addArguments(arguments: _*)
           new FirefoxDriver(options)
         case unhandled =>

--- a/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/multiple-entry-points-snapshot/html.sbt
+++ b/sbt-scalajs-esbuild-web/src/sbt-test/sbt-scalajs-esbuild-web/multiple-entry-points-snapshot/html.sbt
@@ -21,6 +21,11 @@ InputKey[Unit]("html") := {
       case _          => sys.error("missing arguments")
     }
 
+  // Pinned so Selenium Manager fetches a deterministic browser+driver pair
+  // both locally and in CI, instead of resolving against whatever is on PATH.
+  val chromeForTestingVersion = "149.0.7827.22"
+  val firefoxVersion = "151.0.1"
+
   val webBrowser = new WebBrowser
     with Matchers
     with Eventually
@@ -42,27 +47,13 @@ InputKey[Unit]("html") := {
         .map(_.toLowerCase)
         .getOrElse("chrome") match {
         case "chrome" =>
-          sys.env
-            .get("CHROMEDRIVER_BIN")
-            .filter(_.nonEmpty)
-            .foreach(System.setProperty("webdriver.chrome.driver", _))
           val options = new ChromeOptions
-          sys.env
-            .get("CHROME_BIN")
-            .filter(_.nonEmpty)
-            .foreach(options.setBinary)
+          options.setBrowserVersion(chromeForTestingVersion)
           options.addArguments(arguments: _*)
           new ChromeDriver(options)
         case "firefox" =>
-          sys.env
-            .get("GECKODRIVER_BIN")
-            .filter(_.nonEmpty)
-            .foreach(System.setProperty("webdriver.gecko.driver", _))
           val options = new FirefoxOptions
-          sys.env
-            .get("FIREFOX_BIN")
-            .filter(_.nonEmpty)
-            .foreach(options.setBinary)
+          options.setBrowserVersion(firefoxVersion)
           options.addArguments(arguments: _*)
           new FirefoxDriver(options)
         case unhandled =>

--- a/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project-snapshot/html.sbt
+++ b/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project-snapshot/html.sbt
@@ -18,6 +18,11 @@ InputKey[Unit]("html") := {
       case _          => sys.error("missing arguments")
     }
 
+  // Pinned so Selenium Manager fetches a deterministic browser+driver pair
+  // both locally and in CI, instead of resolving against whatever is on PATH.
+  val chromeForTestingVersion = "149.0.7827.22"
+  val firefoxVersion = "151.0.1"
+
   val webBrowser = new WebBrowser
     with Matchers
     with Eventually
@@ -38,27 +43,13 @@ InputKey[Unit]("html") := {
         .map(_.toLowerCase)
         .getOrElse("chrome") match {
         case "chrome" =>
-          sys.env
-            .get("CHROMEDRIVER_BIN")
-            .filter(_.nonEmpty)
-            .foreach(System.setProperty("webdriver.chrome.driver", _))
           val options = new ChromeOptions
-          sys.env
-            .get("CHROME_BIN")
-            .filter(_.nonEmpty)
-            .foreach(options.setBinary)
+          options.setBrowserVersion(chromeForTestingVersion)
           options.addArguments(arguments: _*)
           new ChromeDriver(options)
         case "firefox" =>
-          sys.env
-            .get("GECKODRIVER_BIN")
-            .filter(_.nonEmpty)
-            .foreach(System.setProperty("webdriver.gecko.driver", _))
           val options = new FirefoxOptions
-          sys.env
-            .get("FIREFOX_BIN")
-            .filter(_.nonEmpty)
-            .foreach(options.setBinary)
+          options.setBrowserVersion(firefoxVersion)
           options.addArguments(arguments: _*)
           new FirefoxDriver(options)
         case unhandled =>

--- a/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project-snapshot/html.sbt
+++ b/sbt-web-scalajs-esbuild/src/sbt-test/sbt-web-scalajs-esbuild/basic-project-snapshot/html.sbt
@@ -38,11 +38,27 @@ InputKey[Unit]("html") := {
         .map(_.toLowerCase)
         .getOrElse("chrome") match {
         case "chrome" =>
+          sys.env
+            .get("CHROMEDRIVER_BIN")
+            .filter(_.nonEmpty)
+            .foreach(System.setProperty("webdriver.chrome.driver", _))
           val options = new ChromeOptions
+          sys.env
+            .get("CHROME_BIN")
+            .filter(_.nonEmpty)
+            .foreach(options.setBinary)
           options.addArguments(arguments: _*)
           new ChromeDriver(options)
         case "firefox" =>
+          sys.env
+            .get("GECKODRIVER_BIN")
+            .filter(_.nonEmpty)
+            .foreach(System.setProperty("webdriver.gecko.driver", _))
           val options = new FirefoxOptions
+          sys.env
+            .get("FIREFOX_BIN")
+            .filter(_.nonEmpty)
+            .foreach(options.setBinary)
           options.addArguments(arguments: _*)
           new FirefoxDriver(options)
         case unhandled =>


### PR DESCRIPTION
## Summary
- Pin browser versions consumed by Selenium scripted tests via Selenium Manager. Each `html.sbt` sets `browserVersion` on `ChromeOptions`/`FirefoxOptions` to a hardcoded `chromeForTestingVersion` / `firefoxVersion`, and Selenium Manager downloads the matching browser+driver pair into `~/.cache/selenium` on first run -- same path locally and in CI, so a runner image bump (or a developer's stale local browser) can no longer change the test target.
- Cache `~/.cache/selenium` in the workflow keyed on `runner.os`, `matrix.browser`, and a hash of all `sbt-test/**/html.sbt`, with a `restore-keys` fallback so a version bump only re-downloads the changed browser instead of busting the entire cache.
- Add Renovate coverage for the new pins: custom datasources for the canonical Chrome-for-Testing JSON and Mozilla product-details JSON, regex `customManagers` that extract `chromeForTestingVersion` / `firefoxVersion` from `sbt-test/**/html.sbt`, and `packageRules` grouping updates as `chrome` and `firefox`. Selenium Manager picks the driver matched to the chosen Firefox build, so geckodriver no longer needs its own pin. The Electron Selenium example is already self-pinned via `electron-chromedriver` and is left untouched.

Generated with [Claude Code](https://claude.com/claude-code)