### PR TITLE
Push release branch and tag atomically

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -67,4 +67,6 @@ jobs:
           fi
           git commit -am "Bump examples to version $VERSION"
           git tag -a "v$VERSION" -m "$VERSION"
-          git push origin HEAD:main "refs/tags/v$VERSION"
+          # --atomic so the branch and tag are pushed in a single transaction:
+          # if the branch push is rejected, the tag is not created either.
+          git push --atomic origin HEAD:main "refs/tags/v$VERSION"


### PR DESCRIPTION
## Summary

- Push the release bump commit and the tag with `git push --atomic` in the release preparation workflow, so both refs are updated in a single transaction. Previously they were pushed in one command but applied independently, so a rejected branch push (e.g. by branch protection) could still create the tag, leaving it pointing at a commit that never landed on `main`.

Generated with [Claude Code](https://claude.com/claude-code)