### PR TITLE
Pin coursier sbt app to the 1.x runner

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -47,7 +47,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          apps: sbt
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - name: Write example versions
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - run: sbt exampleVersionCheck ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          apps: sbt
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.84.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:${{ matrix.jdk }}
-          apps: sbt
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+ (breaking the JDK 8 matrix) and parses CLI
+          # commands differently. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - uses: actions/setup-node@v6
         with:
           node-version: 24.15.0

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,13 @@
       "matchStrings": ["val\\s+firefoxVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "firefox",
       "datasourceTemplate": "custom.firefox-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["apps: sbt:(?<currentValue>\\S+)"],
+      "depNameTemplate": "org.scala-sbt:sbt-launch",
+      "datasourceTemplate": "maven"
     }
   ],
   "packageRules": [
@@ -75,6 +82,10 @@
     {
       "matchPackageNames": ["firefox"],
       "groupName": "firefox"
+    },
+    {
+      "matchPackageNames": ["org.scala-sbt:sbt-launch"],
+      "allowedVersions": "<2.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The latest sbt runner installed by `coursier/setup-action`'s `apps: sbt` is sbt 2.x, which requires JDK 17+ and parses CLI commands differently. This broke the JDK 8 and JDK 25 Test matrix jobs and the JDK 11 Scala Steward job, and was a latent failure waiting to bite the release workflows.

- Pin `apps: sbt:1.12.12` in all four workflows (`test.yml`, `scala-steward.yml`, `release-prepare.yml`, `release.yml`).
- Add a Renovate custom manager that tracks `org.scala-sbt:sbt-launch` from the `apps: sbt:<version>` line, capped to `<2.0.0`, so the pin stays in sync with sbt releases.

Generated with [Claude Code](https://claude.com/claude-code)