### PR TITLE
Cap sbt-launch pin below 1.12.13 to keep the sbt 1.x runner

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -47,9 +47,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
+          # not bump past this in renovate.json.
+          apps: sbt:1.12.12
       - name: Write example versions
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
+          # not bump past this in renovate.json.
+          apps: sbt:1.12.12
       - run: sbt exampleVersionCheck ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -20,9 +20,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
+          # not bump past this in renovate.json.
+          apps: sbt:1.12.12
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.90.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,11 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:${{ matrix.jdk }}
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+ (breaking the JDK 8 matrix) and parses CLI
-          # commands differently. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+ (breaking the JDK 8 matrix)
+          # and parses CLI commands differently. Renovate is constrained to not
+          # bump past this in renovate.json.
+          apps: sbt:1.12.12
       - uses: actions/setup-node@v6
         with:
           node-version: 24.18.0

--- a/renovate.json
+++ b/renovate.json
@@ -84,8 +84,9 @@
       "groupName": "firefox"
     },
     {
+      "description": "sbt-launch 1.12.13+ defaults to the sbt 2.x runner, which requires JDK 17+ and breaks the JDK 8 test matrix. Pin to the last sbt 1.x-default launcher.",
       "matchPackageNames": ["org.scala-sbt:sbt-launch"],
-      "allowedVersions": "<2.0.0"
+      "allowedVersions": "<1.12.13"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The pin to the sbt 1.x runner regressed on `main`. Renovate bumped `apps: sbt` from `1.12.12` to `1.12.13` (#666) because the `allowedVersions` guard only blocked `2.0.0+` -- but the sbt 2.x runner default actually ships *inside* the `1.12.13` launcher, which is a `< 2.0.0` version. Combined with the `scala-steward-action` bump to `v2.90.0` (#568), the Scala Steward job then failed with `sbt 2.x requires JDK 17 or above, but you have JDK 11`, and the same launcher breaks the JDK 8 Test matrix.

The `1.12.13` launcher alone is not the trigger -- scalajs-vite runs it fine on `scala-steward-action@v2.84.0`, and scalajs-esbuild's own green run used `v2.90.0` with the `1.12.12` launcher. It is the combination of `v2.90.0` and the `1.12.13` launcher (whose default sbt version flipped to 2.x) that bypasses `project/build.properties` and resolves sbt 2.x.

This pins the launcher back to `1.12.12` and tightens the Renovate `org.scala-sbt:sbt-launch` cap to `<1.12.13`, closing the gap that allowed #666.

Generated with [Claude Code](https://claude.com/claude-code)
