### PR TITLE
Run the Scala Steward job on JDK 17

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: coursier/setup-action@v3
         with:
-          jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          # scala-steward-action v2.90.0 bundles its own sbt 2.x runner, which
+          # requires JDK 17+ regardless of the stewarded project's sbt version.
+          jvm: temurin:17
           apps: sbt:1.12.13
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.90.0


### PR DESCRIPTION
## Summary

The Scala Steward job fails with `sbt 2.x requires JDK 17 or above, but you have JDK 11`.

`scala-steward-action` v2.90.0 installs and runs its own sbt (the `✓ SBT installed` healthcheck step), and that bundled runner is now sbt 2.x, which hard-requires JDK 17+. The job runs on `jvm: temurin:11`, so the moment scala-steward invokes sbt for `Get dependencies in . from sbt`, the runner aborts before it even reads the project's `build.properties`.

This is not related to the `apps: sbt` coursier pin -- scala-steward does not use that sbt. Evidence:

- `scripted-sbt-sources` fails identically with its launcher already pinned to `1.12.12`.
- `scalajs-vite` still passes because it is on `scala-steward-action@v2.84.0`, whose bundled sbt is still 1.x (it ran sbt for ~54s, green on JDK 11).
- This repo's "green" run on the PR branch only passed because it hit the scala-steward workspace cache and skipped the sbt call entirely.

Bumping only this job to `temurin:17` lets the bundled sbt 2.x runner start; it then honors the project's `build.properties` (sbt 1.x) and stewarding proceeds. The other workflows are unaffected -- they invoke sbt directly and run fine on the existing JDKs (the Test matrix passed with `apps: sbt:1.12.13` in #669).

Generated with [Claude Code](https://claude.com/claude-code)
