### PR TITLE
Rename Release run workflow to _release-run

### DIFF
--- a/.github/workflows/_release-run.yml
+++ b/.github/workflows/_release-run.yml
@@ -1,4 +1,3 @@
-name: Release run
 # Reusable pipeline shared by every run kind, called from release.yml. All the
 # kind-specific behaviour is gated on inputs.kind so the logic lives in one
 # place; release.yml decides the kind and selects which caller job runs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   # Decide once what this run does, then fan out to one job per kind so each
   # appears as its own job in the UI and gets least-privilege permissions.
-  # The shared pipeline lives in _run.yml; the jobs below only select it.
+  # The shared pipeline lives in _release-run.yml; the jobs below only select it.
   #   RELEASE       - workflow_dispatch, first attempt: bump, tag, push, publish.
   #   RELEASE_RETRY - workflow_dispatch whose tag is already on origin from a
   #                   prior attempt: skip bump/push, republish the tag (so a
@@ -71,7 +71,7 @@ jobs:
     if: needs.determine.outputs.kind == 'RELEASE'
     permissions:
       contents: read
-    uses: ./.github/workflows/_run.yml
+    uses: ./.github/workflows/_release-run.yml
     with:
       kind: RELEASE
       version: ${{ inputs.version }}
@@ -81,7 +81,7 @@ jobs:
     if: needs.determine.outputs.kind == 'RELEASE_RETRY'
     permissions:
       contents: read
-    uses: ./.github/workflows/_run.yml
+    uses: ./.github/workflows/_release-run.yml
     with:
       kind: RELEASE_RETRY
       version: ${{ inputs.version }}
@@ -91,7 +91,7 @@ jobs:
     if: needs.determine.outputs.kind == 'DRY_RUN'
     permissions:
       contents: read
-    uses: ./.github/workflows/_run.yml
+    uses: ./.github/workflows/_release-run.yml
     with:
       kind: DRY_RUN
     secrets: inherit
@@ -100,7 +100,7 @@ jobs:
     if: needs.determine.outputs.kind == 'SNAPSHOT'
     permissions:
       contents: read
-    uses: ./.github/workflows/_run.yml
+    uses: ./.github/workflows/_release-run.yml
     with:
       kind: SNAPSHOT
     secrets: inherit


### PR DESCRIPTION
## Summary

The reusable release pipeline (`_run.yml`, displayed as "Release run") always appears in the Actions sidebar. A `workflow_call`-only workflow cannot be hidden from the UI, but it can be made to read as internal:

- Rename `_run.yml` to `_release-run.yml`.
- Drop the `name:` field so GitHub displays the file path (`.github/workflows/_release-run.yml`) instead of "Release run", signalling it is an internal reusable workflow not meant to be launched on its own.
- Update the four caller references and the comment in `release.yml`.

No behavioural change to the release pipeline.
