### PR TITLE
Rename leftover viteElectronBuild* task keys to esbuildElectronBuild*

### DIFF
--- a/sbt-scalajs-esbuild-electron/examples/electron-builder/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/electron-builder/build.sbt
@@ -30,9 +30,9 @@ Compile / mainClass := None
 
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.8.1"
 
-val viteElectronBuildPackage =
+val esbuildElectronBuildPackage =
   taskKey[Unit]("Generate package directory with electron-builder")
-val viteElectronBuildDistributable =
+val esbuildElectronBuildDistributable =
   taskKey[Unit]("Package in distributable format with electron-builder")
 
 val perConfigSettings = Seq(Stage.FastOpt, Stage.FullOpt).flatMap { stage =>
@@ -58,8 +58,8 @@ val perConfigSettings = Seq(Stage.FastOpt, Stage.FullOpt).flatMap { stage =>
   }
 
   Seq(
-    stageTask / viteElectronBuildPackage := fn("--dir" :: Nil).value,
-    stageTask / viteElectronBuildDistributable := fn().value
+    stageTask / esbuildElectronBuildPackage := fn("--dir" :: Nil).value,
+    stageTask / esbuildElectronBuildDistributable := fn().value
   )
 }
 inConfig(Compile)(perConfigSettings)

--- a/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-builder-snapshot/test
+++ b/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-builder-snapshot/test
@@ -1,11 +1,11 @@
 $ delete esbuild/package-lock.json
 > clean
-> fastLinkJS/viteElectronBuildPackage
-> fastLinkJS/viteElectronBuildDistributable
+> fastLinkJS/esbuildElectronBuildPackage
+> fastLinkJS/esbuildElectronBuildDistributable
 $ exists esbuild/package-lock.json
 
 $ delete esbuild/package-lock.json
 > clean
-> fullLinkJS/viteElectronBuildPackage
-> fullLinkJS/viteElectronBuildDistributable
+> fullLinkJS/esbuildElectronBuildPackage
+> fullLinkJS/esbuildElectronBuildDistributable
 $ exists esbuild/package-lock.json


### PR DESCRIPTION
## Summary

The `electron-builder` example defined two custom sbt task keys named `viteElectronBuildPackage` / `viteElectronBuildDistributable` -- leftovers from the Vite-based origin. Since this is the esbuild plugin, they have been renamed to `esbuildElectronBuildPackage` / `esbuildElectronBuildDistributable`, along with the references in the corresponding sbt-test script.

The Vite mentions in `README.md` were left untouched, as they are intentional comparisons to scalajs-vite that explain the project design rationale.