### PR TITLE
Pin electron-builder to a single Linux target (AppImage)

### DIFF
--- a/sbt-scalajs-esbuild-electron/examples/electron-builder/esbuild/electron-builder.json5
+++ b/sbt-scalajs-esbuild-electron/examples/electron-builder/esbuild/electron-builder.json5
@@ -16,6 +16,15 @@
       "dmg"
     ]
   },
+  // Single Linux target on purpose: the default (AppImage + snap) builds both
+  // concurrently, and they race extracting build tools into the shared
+  // ~/.cache/electron-builder, intermittently failing with
+  // "ENOENT: ... mkdir .../appimage-<ver>/appimage-<ver>-<rand>".
+  "linux": {
+    "target": [
+      "AppImage"
+    ]
+  },
   "win": {
     "target": [
       {


### PR DESCRIPTION
## Summary

CI intermittently fails in the `electron-builder` scripted test with an error like `ENOENT: no such file or directory, mkdir '.../appimage-<ver>/appimage-<ver>-<rand>'` (e.g. [this run](https://github.com/ptrdom/scalajs-esbuild/actions/runs/28505859242/job/84494006167)).

The example's `electron-builder.json5` set no `linux.target`, so electron-builder fell back to its default of building **AppImage and snap concurrently**. Both extract build tools into the shared `~/.cache/electron-builder`, and that concurrent extraction races, producing the `ENOENT mkdir` failure. electron-builder 26.15.3 already serializes same-tool extraction with per-directory lockfiles yet still hits this, so upgrading does not help — the fix is to remove the concurrency by building a single Linux target.

This pins `linux.target` to `AppImage`, the most portable and self-contained distributable. The scripted test validates the plugin's electron-builder hand-off, which is target-agnostic, so a single target exercises the same code path as two.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>