### PR TITLE
Pin Scala Steward to 0.39.0, the last Java 11 build

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.92.0
         with:
+          # Pin Scala Steward itself. The action otherwise downloads the latest
+          # published version on every run; 0.39.1 dropped the Java 11 build and
+          # requires Java 17+, which breaks the temurin:11 runner above. Renovate
+          # tracks this pin; a bump past 0.39.0 fails on first run until the
+          # runner is moved to JDK 17.
+          scala-steward-version: 0.39.0
           # Pin the sbt and scalafmt versions Scala Steward runs against to the
           # ones used in this repository. Kept in sync by Renovate.
           sbt-version: 1.12.13

--- a/renovate.json
+++ b/renovate.json
@@ -76,6 +76,14 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["scala-steward-version: (?<currentValue>\\S+)"],
+      "depNameTemplate": "scala-steward-org/scala-steward",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^project/build\\.properties$/"],
       "matchStrings": ["sbt\\.version\\s*=\\s*(?<currentValue>\\S+)"],
       "depNameTemplate": "org.scala-sbt:sbt-launch",
@@ -117,6 +125,11 @@
     {
       "matchPackageNames": ["scalameta/scalafmt"],
       "groupName": "scalafmt"
+    },
+    {
+      "description": "Pinned to 0.39.0, the last Java 11 build; 0.39.1+ requires Java 17+ and will fail on the temurin:11 runner in scala-steward.yml. Bump PRs are intentionally left uncapped: a bump beyond 0.39.0 fails first run and is resolved by moving the runner to JDK 17.",
+      "matchPackageNames": ["scala-steward-org/scala-steward"],
+      "groupName": "scala-steward"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pins Scala Steward itself to `0.39.0`, the last release with a Java 11 build. The `scala-steward-action` otherwise downloads the latest published version on every run, and `0.39.1` dropped the Java 11 build and requires Java 17+ -- which breaks the `temurin:11` runner in `scala-steward.yml`.

- `.github/workflows/scala-steward.yml` -- add `scala-steward-version: 0.39.0` with a comment explaining the pin.
- `renovate.json` -- add a custom regex manager so Renovate tracks the pin (via `github-releases`) and a `packageRule` grouping its bump PRs under `scala-steward`. Bumps are intentionally left uncapped: a bump past `0.39.0` fails on first run and is resolved by moving the runner to JDK 17.

Mirrors the equivalent fix in scalajs-vite.

Generated with [Claude Code](https://claude.com/claude-code)