### PR TITLE
Add Electron Forge example and scripted tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       SBT_CHECK_TASKS: scalafmtSbtCheck scalafmtCheckAll test
-      SBT_SCRIPTED_TARGETS: ${{ matrix.jdk == 8 && format('sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0}', matrix.test-suffix) || format('*/*-{0}', matrix.test-suffix) }}
+      SBT_SCRIPTED_TARGETS: ${{ matrix.jdk == 8 && format('sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0} sbt-scalajs-esbuild-electron/electron-forge-{0}', matrix.test-suffix) || format('*/*-{0}', matrix.test-suffix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: coursier/cache-action@v8

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/build.sbt
@@ -1,0 +1,66 @@
+import org.scalajs.linker.interface.ModuleInitializer
+import org.scalajs.sbtplugin.Stage
+import scalajs.esbuild.electron.EsbuildElectronProcessConfiguration
+import scala.sys.process._
+
+enablePlugins(ScalaJSEsbuildElectronPlugin)
+
+ThisBuild / scalaVersion := "2.13.18"
+
+scalaJSModuleInitializers := Seq(
+  ModuleInitializer
+    .mainMethodWithArgs("example.Main", "main")
+    .withModuleID("main"),
+  ModuleInitializer
+    .mainMethodWithArgs("example.Preload", "main")
+    .withModuleID("preload"),
+  ModuleInitializer
+    .mainMethodWithArgs("example.Renderer", "main")
+    .withModuleID("renderer")
+)
+
+Compile / esbuildElectronProcessConfiguration := new EsbuildElectronProcessConfiguration(
+  "main",
+  Set("preload"),
+  Set("renderer")
+)
+
+// Suppress meaningless 'multiple main classes detected' warning
+Compile / mainClass := None
+
+libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.8.1"
+
+val esbuildElectronForgePackage =
+  taskKey[Unit]("Generate package directory with Electron Forge")
+val esbuildElectronForgeMakeDistributable =
+  taskKey[Unit]("Package in distributable format with Electron Forge")
+
+val perConfigSettings = Seq(Stage.FastOpt, Stage.FullOpt).flatMap { stage =>
+  val stageTask = stage match {
+    case Stage.FastOpt => fastLinkJS
+    case Stage.FullOpt => fullLinkJS
+  }
+
+  def fn(args: List[String]) = Def.task {
+    val log = streams.value.log
+
+    (stageTask / esbuildBundle).value
+
+    val targetDir = (esbuildStage / crossTarget).value
+
+    val exitValue = Process(
+      "node" :: "node_modules/@electron-forge/cli/dist/electron-forge.js" :: args,
+      targetDir
+    ).run(log).exitValue()
+    if (exitValue != 0) {
+      sys.error(s"Nonzero exit value: $exitValue")
+    } else ()
+  }
+
+  Seq(
+    stageTask / esbuildElectronForgePackage := fn("package" :: Nil).value,
+    stageTask / esbuildElectronForgeMakeDistributable := fn("make" :: Nil).value
+  )
+}
+inConfig(Compile)(perConfigSettings)
+inConfig(Test)(perConfigSettings)

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/forge.config.js
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/forge.config.js
@@ -1,0 +1,18 @@
+// See https://www.electronforge.io/configuration
+module.exports = {
+  // esbuild already bundles the app into `out`, so Forge must output
+  // elsewhere to avoid clobbering (and recursing into) that directory.
+  outDir: "forge-out",
+  packagerConfig: {
+    // Everything the app needs at runtime is bundled by esbuild into `out`
+    // (electron is provided by the runtime), so only `out` and package.json
+    // need to be packaged - everything else is build-time scaffolding.
+    ignore: (path) =>
+      path !== "" && path !== "/package.json" && !/^\/out(\/|$)/.test(path)
+  },
+  makers: [
+    {
+      name: "@electron-forge/maker-zip"
+    }
+  ]
+};

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/index.html
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    We are using Node.js <span id="node-version"></span>,
+    Chromium <span id="chrome-version"></span>,
+    and Electron <span id="electron-version"></span>.
+
+    <!-- You can also require other files to run in this process -->
+    <script type="module" src="./renderer.js"></script>
+
+    <h1 id="css-hook"></h1>
+  </body>
+</html>

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/package.json
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "electron-project",
+  "private": true,
+  "version": "0.0.0",
+  "main": "out/main.js",
+  "repository": {
+    "url": "git+https://github.com/ptrdom/scalajs-esbuild.git"
+  },
+  "devDependencies": {
+    "esbuild": "0.28.1",
+    "parse5": "8.0.1",
+    "electron": "43.0.0",
+    "@electron-forge/cli": "7.11.2",
+    "@electron-forge/maker-zip": "7.11.2"
+  },
+  "comment": "extract-zip@2 (yauzl@2) silently truncates zip extraction on Node >=24.16, so @electron/get produces an incomplete Electron download and packaging emits nothing while exiting 0. Redirect it to the drop-in @electron-internal/extract-zip until Electron Forge 8 ships the fix. See https://github.com/electron/forge/issues/4277.",
+  "overrides": {
+    "extract-zip": "npm:@electron-internal/extract-zip@1.0.3"
+  }
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/styles.css
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/esbuild/styles.css
@@ -1,0 +1,7 @@
+/* styles.css */
+
+/* Add styles here to customize the appearance of your app */
+
+#css-hook::after {
+    content: 'CSS WORKS!'
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/project/build.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/project/plugins.sbt
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("me.ptrdom" % "sbt-scalajs-esbuild-electron" % "0.1.3")

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/Main.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/Main.scala
@@ -1,0 +1,64 @@
+package example
+
+import example.facade.electron.BrowserWindow
+import example.facade.electron.BrowserWindowConfig
+import example.facade.electron.ElectronGlobals.app
+import example.facade.electron.WebPreferences
+import example.facade.node.NodeGlobals.__dirname
+import example.facade.node.NodeGlobals.process
+import example.facade.node.Path.join
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+
+object Main extends App {
+  // Create the browser window.
+  def createWindow(): Unit = {
+    val mainWindow = new BrowserWindow(new BrowserWindowConfig {
+      override val height = 600
+      override val width = 800
+      override val webPreferences = new WebPreferences {
+        override val preload = join(__dirname, "preload.js")
+      }
+    })
+
+    // and load the index.html of the app.
+    process.env.DEV_SERVER_URL
+      .asInstanceOf[js.UndefOr[String]]
+      .toOption
+      .fold(
+        mainWindow.loadFile(join(__dirname, "../out", "index.html"))
+      )(url => mainWindow.loadURL(url))
+
+    // Open the DevTools.
+    // mainWindow.webContents.openDevTools()
+  }
+
+  // This method will be called when Electron has finished
+  // initialization and is ready to create browser windows.
+  // Some APIs can only be used after this event occurs.
+  app
+    .whenReady()
+    .`then`((_ => {
+      createWindow()
+
+      // On macOS it's common to re-create a window in the app when the
+      // dock icon is clicked and there are no other windows open.
+      app.on(
+        "activate",
+        () => {
+          if (BrowserWindow.getAllWindows().length == 0) createWindow()
+        }
+      )
+    }): js.Function1[Unit, Unit | js.Thenable[Unit]])
+
+  // Quit when all windows are closed, except on macOS. There, it's common
+  // for applications and their menu bar to stay active until the user quits
+  // explicitly with Cmd + Q.
+  app.on(
+    "window-all-close",
+    () => {
+      if (process.platform != "darwin") app.quit()
+    }
+  )
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/Preload.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/Preload.scala
@@ -1,0 +1,42 @@
+package example
+
+import example.facade.node.NodeGlobals.process
+import org.scalajs.dom
+import org.scalajs.dom.document
+import org.scalajs.dom.window
+
+import scala.scalajs.js
+
+/** The preload script runs before. It has access to web APIs as well as
+  * Electron's renderer process modules and some polyfilled Node.js functions.
+  *
+  * https://www.electronjs.org/docs/latest/tutorial/sandbox
+  */
+object Preload extends App {
+  window.addEventListener(
+    "DOMContentLoaded",
+    { (_: dom.Event) =>
+      val replaceText = (selector: String, text: String) => {
+        val element = document.getElementById(selector)
+        if (element != null) element.innerText = text
+      }
+
+      js.Array("chrome", "node", "electron")
+        .foreach(`type` =>
+          replaceText(
+            s"${`type`}-version",
+            process.versions.get(`type`).orNull
+          )
+        )
+    }
+  )
+
+  document.addEventListener(
+    "DOMContentLoaded",
+    { (_: dom.Event) =>
+      val h1 = document.createElement("h1")
+      h1.textContent = "PRELOAD WORKS!"
+      document.body.append(h1)
+    }
+  )
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/Renderer.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/Renderer.scala
@@ -1,0 +1,30 @@
+package example
+
+import org.scalajs.dom
+import org.scalajs.dom.document
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("./styles.css", JSImport.Namespace)
+object Style extends js.Object
+
+/** This file is loaded via the &lt;script&gt; tag in the index.html file and
+  * will be executed in the renderer process for that window. No Node.js APIs
+  * are available in this process because `nodeIntegration` is turned off and
+  * `contextIsolation` is turned on. Use the contextBridge API in `preload.js`
+  * to expose Node.js functionality from the main process.
+  */
+object Renderer extends App {
+  val style = Style
+
+  document.addEventListener(
+    "DOMContentLoaded",
+    { (_: dom.Event) =>
+      val h1 = document.createElement("h1")
+      h1.textContent = "RENDERER WORKS!"
+      document.body.append(h1)
+    }
+  )
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/electron/Electron.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/electron/Electron.scala
@@ -1,0 +1,47 @@
+package example.facade.electron
+
+import example.facade.node.EventEmitter
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+object ElectronGlobals {
+  @js.native
+  @JSImport("electron", "app")
+  def app: Application = js.native
+}
+
+@js.native
+trait Application extends EventEmitter {
+  def whenReady(): js.Promise[Unit]
+  def quit(): Unit
+}
+
+@js.native
+@JSImport("electron", "BrowserWindow")
+class BrowserWindow(config: BrowserWindowConfig) extends js.Object {
+  def loadURL(url: String): js.Promise[Unit] = js.native
+  def loadFile(filePath: String): js.Promise[Unit] = js.native
+  def webContents: WebContents = js.native
+}
+
+trait BrowserWindowConfig extends js.Object {
+  val height: js.UndefOr[Int] = js.undefined
+  val width: js.UndefOr[Int] = js.undefined
+  val webPreferences: js.UndefOr[WebPreferences] = js.undefined
+}
+
+trait WebPreferences extends js.Object {
+  val preload: js.UndefOr[String] = js.undefined
+  val nodeIntegration: js.UndefOr[Boolean] = js.undefined
+}
+
+trait WebContents extends js.Object {
+  def openDevTools(): Unit
+}
+
+@js.native
+@JSImport("electron", "BrowserWindow")
+object BrowserWindow extends js.Object {
+  def getAllWindows(): js.Array[BrowserWindow] = js.native
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/EventEmitter.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/EventEmitter.scala
@@ -1,0 +1,8 @@
+package example.facade.node
+
+import scala.scalajs.js
+
+@js.native
+trait EventEmitter extends js.Object {
+  def on(event: String, listener: js.Function): Unit = js.native
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/Fs.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/Fs.scala
@@ -1,0 +1,10 @@
+package example.facade.node
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+object Fs {
+  @js.native
+  @JSImport("fs", "mkdtempSync")
+  def mkdtempSync(prefix: String): String = js.native
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/Node.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/Node.scala
@@ -1,0 +1,18 @@
+package example.facade.node
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobalScope
+
+@js.native
+@JSGlobalScope
+object NodeGlobals extends js.Object {
+  val process: Process = js.native
+  val __dirname: String = js.native
+}
+
+@js.native
+trait Process extends js.Object {
+  val platform: String = js.native
+  val versions: js.Dictionary[String] = js.native
+  val env: js.Dynamic = js.native
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/OS.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/OS.scala
@@ -1,0 +1,10 @@
+package example.facade.node
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+object OS {
+  @js.native
+  @JSImport("os", "tmpdir")
+  def tmpdir(): String = js.native
+}

--- a/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/Path.scala
+++ b/sbt-scalajs-esbuild-electron/examples/electron-forge/src/main/scala/example/facade/node/Path.scala
@@ -1,0 +1,10 @@
+package example.facade.node
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+object Path {
+  @js.native
+  @JSImport("path", "join")
+  def join(paths: String*): String = js.native
+}

--- a/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-release/.sources
+++ b/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-release/.sources
@@ -1,0 +1,2 @@
+examples/electron-forge
+src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-snapshot

--- a/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-snapshot/.sources
+++ b/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-snapshot/.sources
@@ -1,0 +1,2 @@
+src/sbt-test-utilities
+examples/electron-forge

--- a/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-snapshot/test
+++ b/sbt-scalajs-esbuild-electron/src/sbt-test/sbt-scalajs-esbuild-electron/electron-forge-snapshot/test
@@ -1,0 +1,15 @@
+$ delete esbuild/package-lock.json
+> clean
+> fastLinkJS/esbuildElectronForgePackage
+$ exists target/scala-2.13/esbuild/main/forge-out
+> fastLinkJS/esbuildElectronForgeMakeDistributable
+$ exists target/scala-2.13/esbuild/main/forge-out/make/zip
+$ exists esbuild/package-lock.json
+
+$ delete esbuild/package-lock.json
+> clean
+> fullLinkJS/esbuildElectronForgePackage
+$ exists target/scala-2.13/esbuild/main/forge-out
+> fullLinkJS/esbuildElectronForgeMakeDistributable
+$ exists target/scala-2.13/esbuild/main/forge-out/make/zip
+$ exists esbuild/package-lock.json


### PR DESCRIPTION
Mirrors the existing electron-builder example with an Electron Forge equivalent. The app sources are identical; packaging is driven by the Forge CLI (`electron-forge package` / `make`) against the pre-built esbuild `out` bundle.

## What is added

- `examples/electron-forge` - a full example project mirroring the electron-builder one, with `esbuildElectronForgePackage` / `esbuildElectronForgeMakeDistributable` task keys wrapping the Forge CLI.
- `forge.config.js` uses `maker-zip`, the one maker that produces a runnable app on all three CI runners (Linux/Windows/macOS) without extra system dependencies. Forge `outDir` is set to `forge-out` to avoid colliding with esbuild's own `out`, and `packagerConfig` ignores everything except the bundled output.
- `electron-forge-{snapshot,release}` scripted tests that assert the packaged app and the maker-zip distributable are actually produced, wired into the JDK-8 scripted target list.

## extract-zip override

The example pins an npm override redirecting `extract-zip` to the drop-in `@electron-internal/extract-zip`:

```json
overrides: {
  extract-zip: npm:@electron-internal/extract-zip@1.0.3
}
```

`extract-zip@2` (`yauzl@2`) silently truncates zip extraction on Node >=24.16, which otherwise leaves `@electron/get` with an incomplete Electron download so packaging emits nothing while exiting 0. See electron/forge#4277; fixed upstream in Forge 8.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>