### PR TITLE
Add dry-run mode to the Scala Steward workflow

### DIFF
--- a/.github/scala-steward-dry-run.conf
+++ b/.github/scala-steward-dry-run.conf
@@ -1,0 +1,11 @@
+# Global (default) repo config for the Scala Steward workflow's dry-run kind,
+# passed via the action's repo-config input (scala-steward --repo-config).
+# updates.limit = 0 runs the full update-detection pipeline but opens/updates
+# no PRs (scala-steward-org/scala-steward#1828), so PRs can validate the
+# workflow without side effects.
+#
+# Scala Steward merges this per-field with the repo's own .scala-steward.conf
+# (RepoConfigAlg: global |+| repo), so the repo's updates.ignore and
+# updatePullRequests are preserved; only updates.limit is added here. The
+# effective dry-run config is therefore the live config capped at zero PRs.
+updates.limit = 0

--- a/.github/workflows/_scala-steward-run.yml
+++ b/.github/workflows/_scala-steward-run.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-24.04
     name: Launch Scala Steward
     steps:
+      # DRY_RUN passes repo-config to the action, which reads it from the
+      # workspace, so the repo must be checked out. LIVE needs no checkout:
+      # Scala Steward clones the target repo itself.
+      - uses: actions/checkout@v7
+        if: inputs.kind == 'DRY_RUN'
       - uses: coursier/cache-action@v8
       - uses: coursier/setup-action@v3
         with:

--- a/.github/workflows/_scala-steward-run.yml
+++ b/.github/workflows/_scala-steward-run.yml
@@ -1,0 +1,62 @@
+# Reusable pipeline shared by every run kind, called from scala-steward.yml.
+# All the kind-specific behaviour is gated on inputs.kind so the logic lives in
+# one place; scala-steward.yml decides the kind and selects which caller job
+# runs.
+#   LIVE    - workflow_dispatch / schedule / push to main: real run, GitHub App
+#             auth, opens dependency-update PRs.
+#   DRY_RUN - pull_request: exercise the full update-detection pipeline with
+#             updates.limit = 0 (no PRs) using the read-only github.token.
+on:
+  workflow_call:
+    inputs:
+      kind:
+        description: "LIVE | DRY_RUN"
+        required: true
+        type: string
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    name: Launch Scala Steward
+    steps:
+      - uses: coursier/cache-action@v8
+      - uses: coursier/setup-action@v3
+        with:
+          jvm: temurin:11
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.13
+      # Two separate invocations rather than one with expression-computed
+      # inputs: the auth differs structurally (GitHub App vs github.token), and
+      # passing blank github-app-* inputs risks the action treating App auth as
+      # requested. The version pins are shared verbatim between them.
+      - name: Launch Scala Steward
+        if: inputs.kind == 'LIVE'
+        uses: scala-steward-org/scala-steward-action@v2.92.0
+        with:
+          # Pin Scala Steward itself. The action otherwise downloads the latest
+          # published version on every run; 0.39.1 dropped the Java 11 build and
+          # requires Java 17+, which breaks the temurin:11 runner above. Renovate
+          # tracks this pin; a bump past 0.39.0 fails on first run until the
+          # runner is moved to JDK 17.
+          scala-steward-version: 0.39.0
+          # Pin the sbt and scalafmt versions Scala Steward runs against to the
+          # ones used in this repository. Kept in sync by Renovate.
+          sbt-version: 1.12.13
+          scalafmt-version: 3.11.3
+          github-app-id: ${{ secrets.SCALA_STEWARD_APP_ID }}
+          github-app-installation-id: ${{ secrets.SCALA_STEWARD_APP_INSTALLATION_ID }}
+          github-app-key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
+          github-app-auth-only: true
+      - name: Launch Scala Steward (dry run)
+        if: inputs.kind == 'DRY_RUN'
+        uses: scala-steward-org/scala-steward-action@v2.92.0
+        with:
+          # Kept in sync with the LIVE invocation above (Renovate).
+          scala-steward-version: 0.39.0
+          sbt-version: 1.12.13
+          scalafmt-version: 3.11.3
+          # No github-app-* inputs: the action falls back to the default
+          # read-only github.token (so this also works on fork PRs). The
+          # default repo config forces updates.limit = 0, so no PRs are opened
+          # even before auth would matter.
+          repo-config: .github/scala-steward-dry-run.conf

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 name: Launch Scala Steward
 
@@ -12,32 +15,46 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Deny-all default: each job opts back in to exactly what it needs.
+permissions: {}
+
 jobs:
-  scala-steward:
+  # Decide once what this run does, then fan out to one job per kind so each
+  # appears as its own job in the UI. The shared pipeline lives in
+  # _scala-steward-run.yml; the jobs below only select it.
+  #   LIVE    - workflow_dispatch / schedule / push to main: opens PRs.
+  #   DRY_RUN - pull_request: exercise the pipeline, open no PRs.
+  determine:
     runs-on: ubuntu-24.04
-    name: Launch Scala Steward
+    permissions:
+      contents: read
+    outputs:
+      kind: ${{ steps.kind.outputs.kind }}
     steps:
-      - uses: coursier/cache-action@v8
-      - uses: coursier/setup-action@v3
-        with:
-          jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
-      - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2.92.0
-        with:
-          # Pin Scala Steward itself. The action otherwise downloads the latest
-          # published version on every run; 0.39.1 dropped the Java 11 build and
-          # requires Java 17+, which breaks the temurin:11 runner above. Renovate
-          # tracks this pin; a bump past 0.39.0 fails on first run until the
-          # runner is moved to JDK 17.
-          scala-steward-version: 0.39.0
-          # Pin the sbt and scalafmt versions Scala Steward runs against to the
-          # ones used in this repository. Kept in sync by Renovate.
-          sbt-version: 1.12.13
-          scalafmt-version: 3.11.3
-          github-app-id: ${{ secrets.SCALA_STEWARD_APP_ID }}
-          github-app-installation-id: ${{ secrets.SCALA_STEWARD_APP_INSTALLATION_ID }}
-          github-app-key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
-          github-app-auth-only: true
+      - name: Determine run kind
+        id: kind
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) KIND=DRY_RUN ;;
+            *) KIND=LIVE ;;
+          esac
+          echo "Run kind: $KIND"
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+  live:
+    needs: determine
+    if: needs.determine.outputs.kind == 'LIVE'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_scala-steward-run.yml
+    with:
+      kind: LIVE
+    secrets: inherit
+  dry-run:
+    needs: determine
+    if: needs.determine.outputs.kind == 'DRY_RUN'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_scala-steward-run.yml
+    with:
+      kind: DRY_RUN
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a dry-run mode to the Scala Steward workflow, mirroring the release workflow's structure. `scala-steward.yml` (parent) determines a run kind and fans out to the reusable `_scala-steward-run.yml` pipeline, gated on `inputs.kind`.

- **LIVE** -- `workflow_dispatch` / `schedule` / `push` to `main`: unchanged real run (GitHub App auth, opens dependency-update PRs). The action invocation is byte-for-byte the same as before.
- **DRY_RUN** -- `pull_request` to `main`: exercises the full update-detection pipeline with `updates.limit = 0` (scala-steward-org/scala-steward#1828) so PRs validate the workflow, its sbt/scalafmt pins and the action version without opening any PRs, using the read-only `github.token` (works on fork PRs too).

## Config merging

The dry-run `repo-config` (`.github/scala-steward-dry-run.conf`) is Scala Steward's global/default config, merged per-field with the repo's own `.scala-steward.conf` (`RepoConfigAlg`: `global |+| repo`). The existing `updates.ignore` and `updatePullRequests` are preserved; only `updates.limit = 0` is added. The effective dry-run config is therefore the live config capped at zero PRs.

## Notes

Watch the first dry-run run here to confirm the action falls back cleanly to `github.token` when no `github-app-*` inputs are supplied on v2.92.0. The `updates.limit = 0` cap makes it safe regardless.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>