### PR TITLE
Add web hot-reload e2e tests

### DIFF
--- a/.github/scripts/Invoke-SbtWithRetry.ps1
+++ b/.github/scripts/Invoke-SbtWithRetry.ps1
@@ -1,0 +1,31 @@
+# Runs `sbt <Command>` on Windows, retrying on known sbt boot-race / fast-fail
+# flakiness (actions/runner-images#13629, sbt/sbt#6777). Shared by the scripted
+# and e2e CI steps so the retry logic lives in one place.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)] [string] $Command,
+  [Parameter(Mandatory = $true)] [string] $Label,
+  [int] $MaxAttempts = 3
+)
+
+$logFile = Join-Path $env:RUNNER_TEMP "sbt-$Label.log"
+for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+  if (Test-Path $logFile) { Remove-Item $logFile -Force }
+  & sbt $Command *>&1 | Tee-Object -FilePath $logFile
+  $exit = $LASTEXITCODE
+  if ($exit -eq 0) { exit 0 }
+  $log = if (Test-Path $logFile) { Get-Content $logFile -Raw } else { '' }
+  $retryReason = $null
+  if ($log -match 'Nonzero exit value: -1073740791') {
+    $retryReason = 'Windows fast-fail (-1073740791); see actions/runner-images#13629'
+  } elseif ($log -match 'Could not create lock for .*sbt-(load|server).*_lock' -or $log -match 'ServerAlreadyBootingException') {
+    $retryReason = 'sbt named-pipe lock race on boot; see sbt/sbt#6777'
+  }
+  if ($attempt -lt $MaxAttempts -and $retryReason) {
+    Write-Host "::warning::$retryReason. Retrying $Label (attempt $($attempt + 1)/$MaxAttempts)."
+    Get-Process -Name java,sbt,sbtn,node,esbuild -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 10
+    continue
+  }
+  exit $exit
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     env:
-      SBT_CHECK_TASKS: scalafmtSbtCheck scalafmtCheckAll test
+      SBT_CHECK_TASKS: scalafmtSbtCheck scalafmtCheckAll e2e/scalafmtCheckAll test
       SBT_SCRIPTED_TARGETS: ${{ matrix.jdk == 8 && format('sbt-scalajs-esbuild/*-{0} sbt-scalajs-esbuild-electron/basic-project-{0} sbt-scalajs-esbuild-electron/e2e-test-playwright-node-{0} sbt-scalajs-esbuild-electron/electron-builder-{0} sbt-scalajs-esbuild-electron/electron-forge-{0}', matrix.test-suffix) || format('*/*-{0}', matrix.test-suffix) }}
     steps:
       - uses: actions/checkout@v7
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/selenium
-          key: selenium-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('**/sbt-test/**/html.sbt') }}
+          key: selenium-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('**/sbt-test/**/html.sbt', 'e2e/**/E2ESupport.scala') }}
           restore-keys: |
             selenium-${{ runner.os }}-${{ matrix.browser }}-
       - name: Run tests (Linux/macOS)
@@ -82,26 +82,23 @@ jobs:
         run: |
           & sbt ${{ env.SBT_CHECK_TASKS }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $maxAttempts = 3
-          $logFile = Join-Path $env:RUNNER_TEMP 'sbt-scripted.log'
-          $scripted = "scriptedSequentialPerModule $env:SBT_SCRIPTED_TARGETS"
-          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            if (Test-Path $logFile) { Remove-Item $logFile -Force }
-            & sbt $scripted *>&1 | Tee-Object -FilePath $logFile
-            $exit = $LASTEXITCODE
-            if ($exit -eq 0) { exit 0 }
-            $log = if (Test-Path $logFile) { Get-Content $logFile -Raw } else { '' }
-            $retryReason = $null
-            if ($log -match 'Nonzero exit value: -1073740791') {
-              $retryReason = 'Windows fast-fail (-1073740791); see actions/runner-images#13629'
-            } elseif ($log -match 'Could not create lock for .*sbt-(load|server).*_lock' -or $log -match 'ServerAlreadyBootingException') {
-              $retryReason = 'sbt named-pipe lock race on boot; see sbt/sbt#6777'
-            }
-            if ($attempt -lt $maxAttempts -and $retryReason) {
-              Write-Host "::warning::$retryReason. Retrying scripted (attempt $($attempt+1)/$maxAttempts)."
-              Get-Process -Name java,sbt,sbtn,node,esbuild -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-              Start-Sleep -Seconds 10
-              continue
-            }
-            exit $exit
-          }
+          & "$env:GITHUB_WORKSPACE/.github/scripts/Invoke-SbtWithRetry.ps1" -Command "scriptedSequentialPerModule $env:SBT_SCRIPTED_TARGETS" -Label scripted
+      # Browser-driven hot-reload e2e tests (see `e2e` module). They spawn a
+      # child `sbt ~esbuildServe`, so they need JDK 9+ (process-tree teardown)
+      # and run per channel keyed off test-suffix, mirroring scripted.
+      - name: Run e2e tests (Linux/macOS)
+        if: ${{ matrix.jdk != 8 && !startsWith(matrix.os, 'windows-') }}
+        uses: coactions/setup-xvfb@v1
+        env:
+          E2E_TEST_BROWSER: ${{ matrix.browser }}
+          E2E_CHANNEL: ${{ matrix.test-suffix }}
+        with:
+          run: sbt e2e/test
+      - name: Run e2e tests (Windows, retry on sbt boot race)
+        if: ${{ matrix.jdk != 8 && startsWith(matrix.os, 'windows-') }}
+        shell: pwsh
+        env:
+          E2E_TEST_BROWSER: ${{ matrix.browser }}
+          E2E_CHANNEL: ${{ matrix.test-suffix }}
+        run: |
+          & "$env:GITHUB_WORKSPACE/.github/scripts/Invoke-SbtWithRetry.ps1" -Command "e2e/test" -Label e2e

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,44 @@ InputKey[Unit]("scriptedSequentialPerModule") := Def.inputTaskDyn {
   }
 }.evaluated
 
+// publishLocal the plugins under test before the forked e2e JVM runs, so the
+// copied example builds against the current source (mirroring how scripted's
+// `scriptedDependencies` stages the plugin). Hung off a shared task because
+// `test` and `testOnly` are distinct tasks, so both must depend on it for a
+// local `e2e/testOnly ...` to see fresh plugin artifacts too.
+val e2ePublishPluginsLocal =
+  taskKey[Unit]("publishLocal the web plugin and its base before e2e tests")
+
+// Browser-driven hot-reload e2e tests. Deliberately NOT part of the
+// `scalajs-esbuild` aggregate, so the fast `test` / JDK-8 CI check never runs
+// them; they run only via an explicit `e2e/test` on browser-enabled CI rows.
+lazy val e2e = project
+  .in(file("e2e"))
+  .settings(
+    publish / skip := true,
+    scalaVersion := "2.13.18",
+    Test / fork := true,
+    Test / parallelExecution := false,
+    Test / javaOptions ++= Seq(
+      s"-Dplugin.version=${version.value}",
+      s"-Dplugin.channel=${sys.env.getOrElse("E2E_CHANNEL", "snapshot")}",
+      s"-Dexamples.web=${((`sbt-scalajs-esbuild-web` / baseDirectory).value / "examples").absolutePath}"
+    ),
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % "3.2.20" % Test,
+      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.20" % Test,
+      "org.scalatestplus" %% "selenium-4-9" % "3.2.16.0" % Test,
+      "org.seleniumhq.selenium" % "selenium-java" % "4.46.0" % Test
+    ),
+    e2ePublishPluginsLocal := {
+      (`sbt-scalajs-esbuild` / publishLocal).value
+      (`sbt-scalajs-esbuild-web` / publishLocal).value
+    },
+    Test / test := (Test / test).dependsOn(e2ePublishPluginsLocal).value,
+    Test / testOnly :=
+      (Test / testOnly).dependsOn(e2ePublishPluginsLocal).evaluated
+  )
+
 lazy val `scala-steward-hooks` = project
   .in(file("scala-steward-hooks"))
   .enablePlugins(ScalaJSPlugin)

--- a/e2e/src/test/scala/scalajs/esbuild/e2e/BasicWebProjectHotReloadSpec.scala
+++ b/e2e/src/test/scala/scalajs/esbuild/e2e/BasicWebProjectHotReloadSpec.scala
@@ -1,0 +1,101 @@
+package scalajs.esbuild.e2e
+
+import org.scalatest.concurrent.Eventually
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
+
+// Drives the real `sbt ~esbuildServe` against a copy of `basic-web-project` and
+// asserts that sbt's own file-watch hot-swaps a CSS change in place while a
+// Scala change triggers a full page reload. A `window` marker distinguishes the
+// two: it survives an in-place CSS swap but is cleared by a full reload. The
+// edit/assert cycle runs several times over, with distinct values each round, to
+// prove the watch keeps rebuilding beyond the first change (not just once).
+class BasicWebProjectHotReloadSpec
+    extends AnyFreeSpec
+    with Matchers
+    with Eventually {
+
+  // A reload = sbt detects the change, relinks Scala.js, re-bundles in esbuild,
+  // and pushes the SSE event, so give it room.
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(120, Seconds), interval = Span(1, Seconds))
+
+  "basic-web-project hot-reload under a real `sbt ~esbuildServe`" in {
+    val projectDir = E2ESupport.copyExample("basic-web-project")
+    val port = E2ESupport.freePort()
+    E2ESupport.writeServerPort(projectDir, port)
+    val watch = E2ESupport.startWatch(projectDir, port)
+    try {
+      val driver = E2ESupport.newDriver()
+      try {
+        val stylesCss = projectDir.resolve("esbuild/styles.css")
+        val mainScala = projectDir.resolve("src/main/scala/example/Main.scala")
+
+        eventually {
+          driver.get(s"http://localhost:$port")
+          E2ESupport
+            .js(driver)
+            .executeScript("return document.readyState") shouldBe "complete"
+          E2ESupport.text(driver, "h1") shouldBe "BASIC-WEB-PROJECT WORKS!"
+        }
+
+        eventually {
+          E2ESupport.css(driver, "body", "background-color") shouldBe
+            "rgb(0,191,255)"
+        }
+
+        // Each round: a distinct CSS colour (hot-swapped in place) and a distinct
+        // h1 text (full reload). Values differ every round so a stale bundle can
+        // never satisfy the next assertion. State threads through so each edit
+        // targets the value the previous round left behind.
+        val rounds = Seq(
+          ("red", "rgb(255,0,0)", "updated!", "BASIC-WEB-PROJECT UPDATED!"),
+          ("lime", "rgb(0,255,0)", "revised!", "BASIC-WEB-PROJECT REVISED!"),
+          ("blue", "rgb(0,0,255)", "changed!", "BASIC-WEB-PROJECT CHANGED!")
+        )
+        var currentColor = "deepskyblue"
+        var currentText = "works!"
+
+        rounds.zipWithIndex.foreach { case ((color, rgb, text, h1), index) =>
+          val clue = s"round ${index + 1}: "
+
+          E2ESupport.js(driver).executeScript("window.__marker = 'present';")
+
+          // CSS-only edit: hot-swapped in place, without a full page reload.
+          E2ESupport.edit(stylesCss, currentColor, color)
+          eventually {
+            E2ESupport.css(driver, "body", "background-color") shouldBe rgb
+          }
+          withClue(
+            clue + "marker should survive a CSS hot-swap (no reload): "
+          ) {
+            E2ESupport
+              .js(driver)
+              .executeScript("return window.__marker") shouldBe "present"
+          }
+
+          // Scala.js edit: triggers a full page reload.
+          E2ESupport.edit(mainScala, currentText, text)
+          eventually {
+            E2ESupport.text(driver, "h1") shouldBe h1
+          }
+          withClue(clue + "marker should be cleared by a full reload: ") {
+            E2ESupport
+              .js(driver)
+              .executeScript("return window.__marker") shouldBe null
+          }
+
+          currentColor = color
+          currentText = text
+        }
+      } finally {
+        driver.quit()
+      }
+    } finally {
+      E2ESupport.stopWatch(watch)
+      E2ESupport.deleteRecursively(projectDir)
+    }
+  }
+}

--- a/e2e/src/test/scala/scalajs/esbuild/e2e/E2ESupport.scala
+++ b/e2e/src/test/scala/scalajs/esbuild/e2e/E2ESupport.scala
@@ -1,0 +1,229 @@
+package scalajs.esbuild.e2e
+
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.util.Comparator
+import java.util.concurrent.TimeUnit
+import java.util.regex.Matcher
+
+import org.openqa.selenium.JavascriptExecutor
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.firefox.FirefoxOptions
+
+// Shared machinery for hot-reload e2e specs: copy an example to a throwaway
+// dir, run the real `sbt ~esbuildServe` against it, and drive a browser.
+object E2ESupport {
+
+  // Pinned so Selenium Manager fetches a deterministic browser+driver pair both
+  // locally and in CI, instead of resolving against whatever is on PATH.
+  private val chromeForTestingVersion = "150.0.7871.124"
+  private val firefoxVersion = "152.0"
+
+  private def prop(name: String): String =
+    sys.props.getOrElse(name, sys.error(s"System property [$name] not set"))
+
+  private def isWindows =
+    sys.props.getOrElse("os.name", "").toLowerCase.contains("win")
+
+  /** Copies example `name` into a fresh temp dir (excluding `target` and
+    * `node_modules`) and, on the `snapshot` channel, repoints the copy at the
+    * locally-published plugin version. The original example is never touched.
+    */
+  def copyExample(name: String): Path = {
+    val source = Paths.get(prop("examples.web"), name)
+    if (!Files.isDirectory(source))
+      sys.error(s"Example [$name] not found at [$source]")
+    val target = Files.createTempDirectory(s"e2e-$name-")
+
+    val paths = Files.walk(source)
+    try {
+      paths.forEach { path =>
+        val relative = source.relativize(path)
+        val ignored = (0 until relative.getNameCount).exists { i =>
+          val segment = relative.getName(i).toString
+          segment == "target" || segment == "node_modules"
+        }
+        if (!ignored) {
+          val destination = target.resolve(relative.toString)
+          if (Files.isDirectory(path)) Files.createDirectories(destination)
+          else {
+            Files.createDirectories(destination.getParent)
+            Files.copy(path, destination, StandardCopyOption.REPLACE_EXISTING)
+          }
+        }
+      }
+    } finally paths.close()
+
+    if (prop("plugin.channel") == "snapshot") {
+      val pluginsSbt = target.resolve("project/plugins.sbt")
+      val original =
+        new String(Files.readAllBytes(pluginsSbt), StandardCharsets.UTF_8)
+      val rewritten = original.replaceAll(
+        """("me\.ptrdom"\s*%\s*"[^"]+"\s*%\s*")[^"]+(")""",
+        "$1" + Matcher.quoteReplacement(prop("plugin.version")) + "$2"
+      )
+      if (rewritten == original)
+        sys.error(
+          s"Could not rewrite plugin version in [$pluginsSbt]:\n$original"
+        )
+      Files.write(pluginsSbt, rewritten.getBytes(StandardCharsets.UTF_8))
+    }
+
+    target
+  }
+
+  /** Reserves a currently-free TCP port by binding and releasing it. A small
+    * race exists between release and the child re-binding it, tolerable for a
+    * single sequential spec (and far safer than a fixed port that a leftover
+    * server could already hold).
+    */
+  def freePort(): Int = {
+    val socket = new ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+  }
+
+  /** Pins the dev server's proxy port (the one the browser connects to) for a
+    * copied project by appending an sbt setting, so each spec gets its own port
+    * instead of the plugin default. The key must be `Compile`-scoped: the
+    * plugin installs it via `inConfig(Compile)`, so an unscoped override is
+    * silently ignored. `esbuildServe`/`serverPort` are in scope via the web
+    * plugin's autoImport.
+    */
+  def writeServerPort(projectDir: Path, port: Int): Unit =
+    Files.write(
+      projectDir.resolve("e2e-server-port.sbt"),
+      s"Compile / esbuildServe / serverPort := $port\n"
+        .getBytes(StandardCharsets.UTF_8)
+    )
+
+  def deleteRecursively(path: Path): Unit = {
+    if (Files.exists(path)) {
+      val paths = Files.walk(path)
+      try {
+        paths
+          .sorted(Comparator.reverseOrder[Path]())
+          .forEach(p => Files.deleteIfExists(p))
+      } finally paths.close()
+    }
+  }
+
+  /** Spawns `sbt ~esbuildServe` and blocks until the dev server accepts
+    * connections on `port`.
+    */
+  def startWatch(directory: Path, port: Int): Process = {
+    val launcher = if (isWindows) List("cmd", "/c", "sbt") else List("sbt")
+    val command = new java.util.ArrayList[String]()
+    (launcher :+ "~esbuildServe").foreach(command.add)
+    val builder = new ProcessBuilder(command)
+    builder.directory(directory.toFile)
+    // stdin stays an open, idle pipe: an EOF makes `~` quit immediately.
+    builder.redirectInput(ProcessBuilder.Redirect.PIPE)
+    builder.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+    builder.redirectError(ProcessBuilder.Redirect.INHERIT)
+    val process = builder.start()
+
+    val deadline = System.currentTimeMillis() + 240000
+    var connected = false
+    while (!connected && System.currentTimeMillis() < deadline) {
+      if (!process.isAlive) {
+        sys.error(
+          s"`sbt ~esbuildServe` exited early with code [${process.exitValue()}]"
+        )
+      }
+      val socket = new Socket()
+      try {
+        socket.connect(new InetSocketAddress("localhost", port), 1000)
+        connected = true
+      } catch {
+        case _: Throwable => Thread.sleep(1000)
+      } finally {
+        try socket.close()
+        catch { case _: Throwable => () }
+      }
+    }
+    if (!connected) {
+      stopWatch(process)
+      sys.error(s"Dev server did not start on port [$port] within timeout")
+    }
+    process
+  }
+
+  def stopWatch(process: Process): Unit = {
+    val descendants = new java.util.ArrayList[ProcessHandle]()
+    process.descendants().forEach(descendants.add(_))
+    process.destroy()
+    descendants.forEach(handle => if (handle.isAlive) handle.destroy())
+    if (!process.waitFor(10, TimeUnit.SECONDS)) process.destroyForcibly()
+    descendants.forEach(handle => if (handle.isAlive) handle.destroyForcibly())
+  }
+
+  def newDriver(): WebDriver = {
+    // arguments recommended by https://itnext.io/how-to-run-a-headless-chrome-browser-in-selenium-webdriver-c5521bc12bf0
+    val arguments = Seq(
+      "--disable-gpu",
+      "--window-size=1920,1200",
+      "--ignore-certificate-errors",
+      "--disable-extensions",
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--headless"
+    )
+    sys.env
+      .get("E2E_TEST_BROWSER")
+      .map(_.toLowerCase)
+      .getOrElse("chrome") match {
+      case "chrome" =>
+        val options = new ChromeOptions
+        options.setBrowserVersion(chromeForTestingVersion)
+        options.addArguments(arguments: _*)
+        new ChromeDriver(options)
+      case "firefox" =>
+        val options = new FirefoxOptions
+        options.setBrowserVersion(firefoxVersion)
+        options.addArguments(arguments: _*)
+        new FirefoxDriver(options)
+      case unhandled =>
+        sys.error(s"Unhandled browser [$unhandled]")
+    }
+  }
+
+  def js(driver: WebDriver): JavascriptExecutor =
+    driver.asInstanceOf[JavascriptExecutor]
+
+  def text(driver: WebDriver, selector: String): AnyRef =
+    js(driver).executeScript(
+      "const e = document.querySelector(arguments[0]); return e && e.textContent",
+      selector
+    )
+
+  /** Computed style value with whitespace stripped (e.g. `rgb(0,191,255)`). */
+  def css(driver: WebDriver, selector: String, property: String): String = {
+    val value = js(driver).executeScript(
+      "return getComputedStyle(document.querySelector(arguments[0]))[arguments[1]]",
+      selector,
+      property
+    )
+    Option(value).map(_.toString.replaceAll("\\s", "")).orNull
+  }
+
+  /** Targeted edit of a copied source file; fails if `from` is not present. */
+  def edit(path: Path, from: String, to: String): Unit = {
+    val original = new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+    if (!original.contains(from))
+      sys.error(s"Expected to find [$from] in [$path]")
+    Files.write(
+      path,
+      original.replace(from, to).getBytes(StandardCharsets.UTF_8)
+    )
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/sbt-test/.+/html\\.sbt$/"],
+      "managerFilePatterns": ["/sbt-test/.+/html\\.sbt$/", "/^e2e/.+/E2ESupport\\.scala$/"],
       "matchStrings": ["val\\s+chromeForTestingVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "chrome-for-testing",
       "datasourceTemplate": "custom.chrome-for-testing-stable",
@@ -51,7 +51,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/sbt-test/.+/html\\.sbt$/"],
+      "managerFilePatterns": ["/sbt-test/.+/html\\.sbt$/", "/^e2e/.+/E2ESupport\\.scala$/"],
       "matchStrings": ["val\\s+firefoxVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "firefox",
       "datasourceTemplate": "custom.firefox-releases"


### PR DESCRIPTION
## Summary

Resolves #249 for the web plugin. Adds browser-driven hot-reload e2e tests.

A new, non-aggregated `e2e` sbt subproject runs ScalaTest + Selenium specs that spawn the real `sbt ~esbuildServe` watch against a throwaway copy of an example project and assert hot-reload behaviour end to end. A CSS edit is hot-swapped in place without a page reload, while a Scala.js edit triggers a full reload; a `window` marker distinguishes the two. The edit/assert cycle runs several rounds with distinct values to prove the watch keeps rebuilding beyond the first change.

## Design

* The `e2e` subproject is deliberately excluded from the `scalajs-esbuild` aggregate, so `sbt test` and the JDK 8 CI check never touch it; it runs only via an explicit `e2e/test`.
* Runs against copies of existing examples, never the originals; on the `snapshot` channel the copy's plugin version is repointed to the locally published build.
* Snapshot/release parity with the scripted tests, keyed off `E2E_CHANNEL` (`matrix.test-suffix`).
* Each spec allocates a free ephemeral port and pins it via `Compile / esbuildServe / serverPort`, so runs never collide on a fixed `3000`.
* The child watch is torn down via the process tree (`Process#descendants()`), which needs JDK 9+, hence the JDK 25 CI rows.

## CI

* New `e2e/test` steps on the JDK 25 rows for both channels (Linux/macOS under xvfb; Windows under the shared retry wrapper).
* The duplicated Windows sbt boot-race retry loops are extracted into a shared `.github/scripts/Invoke-SbtWithRetry.ps1`.
* Renovate tracks the pinned Chrome-for-Testing and Firefox versions in `E2ESupport.scala`, and the Selenium browser cache key hashes that file too.

## Follow-up

Electron hot-reload e2e tests will land as a separate PR in the same `e2e` module, with Selenium attaching to the plugin-spawned Electron via a remote-debug port.

Generated with [Claude Code](https://claude.com/claude-code)
